### PR TITLE
Fixed issue #29: Android: getUserMedia does not work for capturing audio only

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -325,7 +325,8 @@ class GetUserMediaImpl{
             }
         }
 
-        boolean requestScreenCapturer =  videoConstraintsMandatory.hasKey("chromeMediaSource") &&
+        boolean requestScreenCapturer = videoConstraintsMandatory != null &&
+                videoConstraintsMandatory.hasKey("chromeMediaSource") &&
                 videoConstraintsMandatory.getString("chromeMediaSource").equals("desktop");
 
         final ArrayList<String> requestPermissions = new ArrayList<>();


### PR DESCRIPTION
Fixed the NPE by adding a null check. Tested manually. 