### PR TITLE
Fixed issue #49: The plugin is incompatible with use_frameworks in Podfile

### DIFF
--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -18,5 +18,6 @@ A new flutter plugin project.
   s.dependency 'libyuv-iOS'
   s.dependency 'GoogleWebRTC', '1.1.25821'
   s.ios.deployment_target = '9.0'
+  s.static_framework = true
 end
 


### PR DESCRIPTION
I found the corresponding command than needs to be added to the podspec file here: http://guides.cocoapods.org/syntax/podspec.html#static_framework

After this change, I was able to compile my project with `use_frameworks!`. I also verified that the example project compiles and runs if I add `use_frameworks!` to its Podfile. 