### PR TITLE
Migrated to AndroidX using Refactoring from Andoid Studio

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         minSdkVersion 18
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     lintOptions {
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     api 'org.webrtc:google-webrtc:1.0.26131'
-    implementation "com.android.support:support-annotations:22.0.0"
+    implementation "androidx.annotation:annotation:1.1.0-alpha01"
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -12,7 +12,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.ResultReceiver;
 import android.provider.MediaStore;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 import android.content.Intent;
 import android.app.Activity;

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import android.util.Base64;
 import android.util.Log;
 import android.util.SparseArray;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.cloudwebrtc.webrtc.utils.ConstraintsArray;
 import com.cloudwebrtc.webrtc.utils.ConstraintsMap;

--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/MediaRecorderImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/MediaRecorderImpl.java
@@ -1,6 +1,6 @@
 package com.cloudwebrtc.webrtc.record;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.cloudwebrtc.webrtc.utils.EglUtils;

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -28,7 +28,7 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -56,6 +56,6 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+    androidTestImplementation 'androidx.test:runner:1.1.2-alpha01'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.2-alpha01'
 }


### PR DESCRIPTION
Since Flutter 1.1.8 was released, it created a bit of a havoc in the Flutter community because of migrating to [AndroidX](https://developer.android.com/jetpack/androidx/). AndroidX replaces the Google Android support libraries, which has been an issue because of version compatibility. Here are some of the open issues related to AndroidX support that I came across as someone who uses a lot of Flutter plugins in a single app:
[Plugins are broken since move to AndroidX](https://github.com/flutter/flutter/issues/27106)
[Plugins do not support AndroidX](https://github.com/flutter/flutter/issues/23995)

Flutter-webrtc happens to be one of the plugins that's causing issues since migrating to AndroidX. While there's an interesting workaround for utilizing non-AndroidX plugin which involves setting `android.enableJetifier=true`, that workaround is not perfect and it doesn't address the core issue which is the inability of different versions of support libraries to co-exist. The right thing to do is to migrate all Flutter plugins to AndroidX. This commit is exactly that. I performed automatic migration by using the Refactoring method described in this document: [Migrating to AndroidX](https://developer.android.com/jetpack/androidx/migrate). 

I tested my changes by running the example project on iOS and Android.