### PR TITLE
Fix indentation in peer connection factory

### DIFF
--- a/lib/rtc_peerconnection_factory.dart
+++ b/lib/rtc_peerconnection_factory.dart
@@ -3,24 +3,24 @@ import 'package:flutter/services.dart';
 import 'rtc_peerconnection.dart';
 import 'utils.dart';
 
-Future<RTCPeerConnection> createPeerConnection(Map<String,dynamic> configuration, Map<String,dynamic> constraints) async {
+Future<RTCPeerConnection> createPeerConnection(Map<String, dynamic> configuration, Map<String, dynamic> constraints) async {
   MethodChannel channel = WebRTC.methodChannel();
 
   Map<String, dynamic> defaultConstraints = {
-      "mandatory": {},
-      "optional": [
-        {"DtlsSrtpKeyAgreement": true },
-      ],
-    };
+    "mandatory": {},
+    "optional": [
+      {"DtlsSrtpKeyAgreement": true},
+    ],
+  };
 
-    final Map<dynamic, dynamic> response = await channel.invokeMethod(
-      'createPeerConnection',
-      <String, dynamic>{
-        'configuration': configuration,
-        'constraints': constraints.length == 0? defaultConstraints : constraints
-      },
-    );
+  final Map<dynamic, dynamic> response = await channel.invokeMethod(
+    'createPeerConnection',
+    <String, dynamic>{
+      'configuration': configuration,
+      'constraints': constraints.length == 0 ? defaultConstraints : constraints
+    },
+  );
 
-    String peerConnectionId = response['peerConnectionId'];
-    return new RTCPeerConnection(peerConnectionId);
+  String peerConnectionId = response['peerConnectionId'];
+  return new RTCPeerConnection(peerConnectionId);
 }


### PR DESCRIPTION
Seems like the entire function after line 9 was indentated by an extra level, this patch fixes that and some other minor whitespace things ☺️ 