### PR TITLE
Change datachannel message type identifier from a string to an enum, and remove it altogether from the send method and message listener.

### DIFF
--- a/example/lib/src/data_channel_sample.dart
+++ b/example/lib/src/data_channel_sample.dart
@@ -54,15 +54,15 @@ class _DataChannelSampleState extends State<DataChannelSample> {
   /// Send some sample messages and handle incoming messages.
   _onDataChannel(RTCDataChannel dataChannel) {
     dataChannel.onMessage = (type, message) {
-      if (type == "text") {
+      if (type == MessageType.text) {
         print(message.text);
       }
       else {
         // do something with message.binary
       }
     };
-    dataChannel.send("text", RTCDataChannelMessage("Hello!"));
-    dataChannel.send("binary", RTCDataChannelMessage.fromBinary(
+    dataChannel.send(MessageType.text, RTCDataChannelMessage("Hello!"));
+    dataChannel.send(MessageType.binary, RTCDataChannelMessage.fromBinary(
       Uint8List(5)
     ));
   }

--- a/example/lib/src/data_channel_sample.dart
+++ b/example/lib/src/data_channel_sample.dart
@@ -53,8 +53,8 @@ class _DataChannelSampleState extends State<DataChannelSample> {
 
   /// Send some sample messages and handle incoming messages.
   _onDataChannel(RTCDataChannel dataChannel) {
-    dataChannel.onMessage = (type, message) {
-      if (type == MessageType.text) {
+    dataChannel.onMessage = (message) {
+      if (message.type == MessageType.text) {
         print(message.text);
       }
       else {

--- a/example/lib/src/data_channel_sample.dart
+++ b/example/lib/src/data_channel_sample.dart
@@ -61,8 +61,8 @@ class _DataChannelSampleState extends State<DataChannelSample> {
         // do something with message.binary
       }
     };
-    dataChannel.send(MessageType.text, RTCDataChannelMessage("Hello!"));
-    dataChannel.send(MessageType.binary, RTCDataChannelMessage.fromBinary(
+    dataChannel.send(RTCDataChannelMessage("Hello!"));
+    dataChannel.send(RTCDataChannelMessage.fromBinary(
       Uint8List(5)
     ));
   }

--- a/lib/rtc_data_channel.dart
+++ b/lib/rtc_data_channel.dart
@@ -95,7 +95,7 @@ enum RTCDataChannelState {
 }
 
 typedef void RTCDataChannelStateCallback(RTCDataChannelState state);
-typedef void RTCDataChannelOnMessageCallback(MessageType type, RTCDataChannelMessage message);
+typedef void RTCDataChannelOnMessageCallback(RTCDataChannelMessage message);
 
 /// A class that represents a WebRTC datachannel.
 /// Can send and receive text and binary messages.
@@ -113,9 +113,8 @@ class RTCDataChannel {
 
   /// Event handler for messages. Assign this property 
   /// to listen for messages from this [RTCDataChannel].
-  /// Will be passed a [type] argument telling the type of message recieved 
-  /// and a [message] argument, which is an [RTCDataChannelMessage] that will contain either
-  /// binary data as a [Uint8List] or text data as a [String], as defined by [type].
+  /// Will be passed a a [message] argument, which is an [RTCDataChannelMessage] that will contain either
+  /// binary data as a [Uint8List] or text data as a [String].
   RTCDataChannelOnMessageCallback onMessage;
 
   RTCDataChannel(this._peerConnectionId, this._label, this._dataChannelId){
@@ -153,7 +152,7 @@ class RTCDataChannel {
         }
 
         if (this.onMessage != null)
-          this.onMessage(type, message);
+          this.onMessage(message);
         break;
     }
   }
@@ -169,14 +168,12 @@ class RTCDataChannel {
   }
 
   /// Send a message to this datachannel.
-  /// To send a text message, pass [MessageType.text] to [type]
-  /// And use the default constructor to instantiate a text [RTCDataChannelMessage]
+  /// To send a text message, use the default constructor to instantiate a text [RTCDataChannelMessage]
   /// for the [message] parameter.
-  /// To send a binary message, pass [MessageType.binary] to [type]
-  /// and pass a binary [RTCDataChannelMessage]
+  /// To send a binary message, pass a binary [RTCDataChannelMessage]
   /// constructed with [RTCDataChannelMessage.fromBinary]
   /// or [RTCDataChannelMessage.fromBase64Binary].
-  Future<void> send(MessageType type, RTCDataChannelMessage message) async {
+  Future<void> send(RTCDataChannelMessage message) async {
     dynamic data;
     if (message.isBinary) {
       if (Platform.isAndroid) {
@@ -193,7 +190,7 @@ class RTCDataChannel {
       <String, dynamic>{
         'peerConnectionId': _peerConnectionId,
         'dataChannelId': _dataChannelId,
-        'type': _messageTypeToTypeString[type],
+        'type': _messageTypeToTypeString[message.isBinary ? "binary" : "text"],
         'data': data
       }
     );

--- a/lib/rtc_data_channel.dart
+++ b/lib/rtc_data_channel.dart
@@ -190,7 +190,7 @@ class RTCDataChannel {
       <String, dynamic>{
         'peerConnectionId': _peerConnectionId,
         'dataChannelId': _dataChannelId,
-        'type': _messageTypeToTypeString[message.isBinary ? "binary" : "text"],
+        'type': message.isBinary ? "binary" : "text",
         'data': data
       }
     );


### PR DESCRIPTION
Map lookups should be faster than string comparisons, so this will likely improve performance.
This will change the API (again) but it will also make it safer, since the compiler will notify you if you mistype the identifier as an enum.

I also did some slight reformatting elsewhere in the file.