### PR TITLE
Workaround for WebRTC issue 10588

### DIFF
--- a/ios/Classes/FlutterRTCDataChannel.m
+++ b/ios/Classes/FlutterRTCDataChannel.m
@@ -25,6 +25,16 @@
     objc_setAssociatedObject(self, @selector(eventSink), eventSink, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+- (NSNumber *)flutterChannelId
+{
+    return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setFlutterChannelId:(NSNumber *)flutterChannelId
+{
+    objc_setAssociatedObject(self, @selector(flutterChannelId), flutterChannelId, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 - (FlutterEventChannel *)eventChannel
 {
     return objc_getAssociatedObject(self, _cmd);
@@ -59,10 +69,11 @@
     RTCPeerConnection *peerConnection = self.peerConnections[peerConnectionId];
     RTCDataChannel *dataChannel = [peerConnection dataChannelForLabel:label configuration:config];
     
-    if (nil != dataChannel && -1 != dataChannel.channelId) {
+    if (nil != dataChannel) {
         dataChannel.peerConnectionId = peerConnectionId;
-        NSNumber *dataChannelId = [NSNumber numberWithInteger:dataChannel.channelId];
+        NSNumber *dataChannelId = [NSNumber numberWithInteger:config.channelId];
         peerConnection.dataChannels[dataChannelId] = dataChannel;
+        dataChannel.flutterChannelId = dataChannelId;
         dataChannel.delegate = self;
         
         FlutterEventChannel *eventChannel = [FlutterEventChannel

--- a/ios/Classes/FlutterRTCDataChannel.m
+++ b/ios/Classes/FlutterRTCDataChannel.m
@@ -156,7 +156,7 @@
     FlutterEventSink eventSink = channel.eventSink;
     if(eventSink) {
         eventSink(@{ @"event" : @"dataChannelReceiveMessage",
-                     @"id": @(channel.channelId),
+                     @"id": @(channel.flutterChannelId),
                      @"type": type,
                      @"data": (data ? data : [NSNull null])});
     }

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'libyuv-iOS'
-  s.dependency 'GoogleWebRTC', '1.1.27299' # DON'T UPDATE UNTIL FIXED: https://bugs.chromium.org/p/webrtc/issues/detail?id=10588
+  s.dependency 'GoogleWebRTC', '1.1.27299'
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end


### PR DESCRIPTION
See https://bugs.chromium.org/p/webrtc/issues/detail?id=10588

Yeah, it's hacky, if anyone has better solution - welcome

We could use label instead, but developers tend to use the same label for all data channels

Or we will be stuck with current WebRTC version