### PR TITLE
Add streaming API for datachannel messages and state changes.

### DIFF
--- a/example/lib/src/data_channel_sample.dart
+++ b/example/lib/src/data_channel_sample.dart
@@ -61,6 +61,16 @@ class _DataChannelSampleState extends State<DataChannelSample> {
         // do something with message.binary
       }
     };
+    // or alternatively:
+    dataChannel.messageStream.listen((message) {
+      if (message.type == MessageType.text) {
+        print(message.text);
+      }
+      else {
+        // do something with message.binary
+      }
+    });
+    
     dataChannel.send(RTCDataChannelMessage("Hello!"));
     dataChannel.send(RTCDataChannelMessage.fromBinary(
       Uint8List(5)

--- a/lib/rtc_data_channel.dart
+++ b/lib/rtc_data_channel.dart
@@ -218,8 +218,8 @@ class RTCDataChannel {
   }
 
   Future<void> close() async {
-    _stateChangeController.close();
-    _messageController.close();
+    await _stateChangeController.close();
+    await _messageController.close();
     await _eventSubscription?.cancel();
     await _channel.invokeMethod('dataChannelClose',
         <String, dynamic>{'peerConnectionId': _peerConnectionId, 'dataChannelId': _dataChannelId});

--- a/lib/rtc_data_channel.dart
+++ b/lib/rtc_data_channel.dart
@@ -126,9 +126,11 @@ class RTCDataChannel {
   final _messageController = StreamController<RTCDataChannelMessage>.broadcast(sync: true);
 
   /// Stream of state change events. Emits the new state on change.
+  /// Closes when the [RTCDataChannel] is closed.
   Stream<RTCDataChannelState> stateChangeStream;
 
   /// Stream of incoming messages. Emits the message.
+  /// Closes when the [RTCDataChannel] is closed.
   Stream<RTCDataChannelMessage> messageStream;
 
   RTCDataChannel(this._peerConnectionId, this._label, this._dataChannelId) {

--- a/lib/rtc_data_channel.dart
+++ b/lib/rtc_data_channel.dart
@@ -122,8 +122,8 @@ class RTCDataChannel {
   /// binary data as a [Uint8List] or text data as a [String].
   RTCDataChannelOnMessageCallback onMessage;
 
-  final _stateChangeController = StreamController<RTCDataChannelState>.broadcast();
-  final _messageController = StreamController<RTCDataChannelMessage>.broadcast();
+  final _stateChangeController = StreamController<RTCDataChannelState>.broadcast(sync: true);
+  final _messageController = StreamController<RTCDataChannelMessage>.broadcast(sync: true);
 
   /// Stream of state change events. Emits the new state on change.
   Stream<RTCDataChannelState> stateChangeStream;
@@ -146,10 +146,10 @@ class RTCDataChannel {
       case 'dataChannelStateChanged':
         //int dataChannelId = map['id'];
         _state = rtcDataChannelStateForString(map['state']);
-        _stateChangeController.add(_state);
         if (this.onDataChannelState != null) {
           this.onDataChannelState(_state);
         }
+        _stateChangeController.add(_state);
         break;
       case 'dataChannelReceiveMessage':
         //int dataChannelId = map['id'];
@@ -168,9 +168,10 @@ class RTCDataChannel {
         else {
           message = RTCDataChannelMessage(data);
         }
-        _messageController.add(message);
-        if (this.onMessage != null)
+        if (this.onMessage != null) {
           this.onMessage(message);
+        }
+        _messageController.add(message);
         break;
     }
   }


### PR DESCRIPTION
This change adds a streaming API to the `RTCDataChannel`. Adds `stateChangeStream` and `messageStream` to the `RTCDataChannel` class, which are broadcast streams that emit state changes and messages, just as would be passed to the `onDataChannelState` and `onMessage` handlers. This allows for easily attaching multiple listeners to these events, whereas previously the class could only support one handler for each. 

Adds functionality from my own wrapper utility class:

```dart
class StreamingRTCDataChannel {
  RTCDataChannel dataChannel;
  final _messageController = StreamController<RTCDataChannelMessage>.broadcast();
  final _stateChangeController = StreamController<RTCDataChannelState>.broadcast();
  Stream<RTCDataChannelMessage> message;
  Stream<RTCDataChannelState> stateChange;
  StreamingRTCDataChannel(this.dataChannel) {
    message = _messageController.stream;
    stateChange = _stateChangeController.stream;
    dataChannel.onMessage = _messageController.add;
    dataChannel.onDataChannelState = _stateChangeController.add;
  }
}
```

Which will no longer be necessary after this change.

Also updates the datachannel example code to show usage.

This change has been tested within our own app and will not break the existing API, as it's only adding new properties to the class. It should not cause any performance issues, since broadcast streams don't buffer their events and only deliver them to active listeners on demand. If nothing is listening, events are simply discarded.