### PR TITLE
Remove legacy plugin definitions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,6 @@ dependencies:
 
 flutter:
   plugin:
-    androidPackage: com.cloudwebrtc.webrtc
-    pluginClass: FlutterWebRTCPlugin
     platforms:
       android:
         package: com.cloudwebrtc.webrtc


### PR DESCRIPTION
(reverts #143, fixes #147)

On Flutter 1.10 and above, you can't mix legacy plugin definitions with the newer format (see https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/plugins.dart#L186-L192)

This PR removes the old style plugin definitions which breaks Flutter 1.9 and below. If it's merged, the plugin version should probably be bumped to `0.2.0`.