### PR TITLE
Fix RtcVideoView not rebuild when setState called and renderer is cha…

### DIFF
--- a/lib/rtc_video_view.dart
+++ b/lib/rtc_video_view.dart
@@ -108,39 +108,37 @@ class RTCVideoRenderer {
 
 class RTCVideoView extends StatefulWidget {
   final RTCVideoRenderer _renderer;
-  RTCVideoView(this._renderer);
+  RTCVideoView(this._renderer, {Key key}) : super(key: key);
   @override
-  _RTCVideoViewState createState() => new _RTCVideoViewState(_renderer);
+  _RTCVideoViewState createState() => new _RTCVideoViewState();
 }
 
 class _RTCVideoViewState extends State<RTCVideoView> {
-  final RTCVideoRenderer _renderer;
   double _aspectRatio;
   RTCVideoViewObjectFit _objectFit;
   bool _mirror;
-  _RTCVideoViewState(this._renderer);
 
   @override
   void initState() {
     super.initState();
     _setCallbacks();
-    _aspectRatio = _renderer.aspectRatio;
-    _mirror = _renderer.mirror;
-    _objectFit = _renderer.objectFit;
+    _aspectRatio = widget._renderer.aspectRatio;
+    _mirror = widget._renderer.mirror;
+    _objectFit = widget._renderer.objectFit;
   }
 
   @override
   void deactivate() {
     super.deactivate();
-    _renderer.onStateChanged = null;
+    widget._renderer.onStateChanged = null;
   }
 
   void _setCallbacks() {
-    _renderer.onStateChanged = () {
+    widget._renderer.onStateChanged = () {
       setState(() {
-        _aspectRatio = _renderer.aspectRatio;
-        _mirror = _renderer.mirror;
-        _objectFit = _renderer.objectFit;
+        _aspectRatio = widget._renderer.aspectRatio;
+        _mirror = widget._renderer.mirror;
+        _objectFit = widget._renderer.objectFit;
       });
     };
   }
@@ -163,13 +161,13 @@ class _RTCVideoViewState extends State<RTCVideoView> {
                           ..rotateY(_mirror ? -pi : 0.0),
                         alignment: FractionalOffset.center,
                         child:
-                            new Texture(textureId: _renderer._textureId))))));
+                            new Texture(textureId: widget._renderer._textureId))))));
   }
 
   @override
   Widget build(BuildContext context) {
     bool renderVideo =
-        (_renderer._textureId != null && _renderer._srcObject != null);
+        (widget._renderer._textureId != null && widget._renderer._srcObject != null);
 
     return new LayoutBuilder(
         builder: (BuildContext context, BoxConstraints constraints) {


### PR DESCRIPTION
Fix in following dart code:
``` dart
Widget build(BuildContext context) {
  Stack(
  children: <Widget>[
    Positioned(
      left: 0,
      right: 0,
      top: 0,
      bottom: 0,
      child: RTCVideoView(_swap ? session.localRenderer : session.remoteRenderer),
    ),
    Positioned(
      right: 16,
      top: 16,
      width: 72,
      height: 120,
      child: GestureDetector(
        child: RTCVideoView(_swap ? session.remoteRenderer : session.localRenderer),
        onTap: () {
          setState(() {
            _swap = !_swap;
          });
        },
      ),
    ),
  ],
)
}
```
local and remote renderer will not swap when tap on small video view.