### PR TITLE
docs(readme): missing back tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This entry allows your app to access camera and microphone.
 
 ### Android
 
-Ensure the following permission is present in your Android Manifest file, located in `<project root>/android/app/src/main/AndroidManifest.xml:
+Ensure the following permission is present in your Android Manifest file, located in `<project root>/android/app/src/main/AndroidManifest.xml`:
 
 ```xml
 <uses-feature android:name="android.hardware.camera" />


### PR DESCRIPTION
It is causing an issue on pub.dev where you can't see the path https://pub.dev/packages/flutter_webrtc