### PR TITLE
Replace Libyuv dependency, fixing #168

### DIFF
--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'libyuv-iOS'
+  s.dependency 'Libyuv', '1703'
   s.dependency 'GoogleWebRTC', '1.1.29400'
   s.ios.deployment_target = '10.0'
   s.static_framework = true


### PR DESCRIPTION
Fixes #168 

Created my own fork which uses same binary as https://github.com/waitingsnow/libyuv-iOS/ with updated headers. Tested on example project + our production app.