### PR TITLE
Use proper state lifecycle method for nulling renderer state changed handler

### DIFF
--- a/lib/rtc_video_view.dart
+++ b/lib/rtc_video_view.dart
@@ -128,8 +128,8 @@ class _RTCVideoViewState extends State<RTCVideoView> {
   }
 
   @override
-  void deactivate() {
-    super.deactivate();
+  void dispose() {
+    super.dispose();
     widget._renderer.onStateChanged = null;
   }
 

--- a/lib/web/rtc_video_view.dart
+++ b/lib/web/rtc_video_view.dart
@@ -171,8 +171,8 @@ class _RTCVideoViewState extends State<RTCVideoView> {
   }
 
   @override
-  void deactivate() {
-    super.deactivate();
+  void dispose() {
+    super.dispose();
     _renderer.onStateChanged = null;
   }
 


### PR DESCRIPTION
Currently used [deactivate](https://api.flutter.dev/flutter/widgets/State/deactivate.html) method can be called many times during a state lifecycle.
(For example, it called several times during animation, which occurs when `Scaffold` with
`RTCVideoView` is shown with regular route push animation.)

Actually, subclasses should override `deactivate` method to clean up any links between
this object and other elements in the tree (e.g. if you have provided an ancestor with
a pointer to a descendant's RenderObject). _/ adapted quote from [State objects lifecycle](https://api.flutter.dev/flutter/widgets/State-class.html)_