### PR TITLE
[macOS] Fix hot restart videoCapturer crash

### DIFF
--- a/macos/Classes/FlutterRTCMediaStream.m
+++ b/macos/Classes/FlutterRTCMediaStream.m
@@ -290,6 +290,9 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream *mediaStream);
     
     if (videoDevice) {
         RTCVideoSource *videoSource = [self.peerConnectionFactory videoSource];
+        if(self.videoCapturer){
+            [self.videoCapturer stopCapture];
+        }
         self.videoCapturer = [[RTCCameraVideoCapturer alloc] initWithDelegate:videoSource];
         AVCaptureDeviceFormat *selectedFormat = [self selectFormatForDevice:videoDevice];
         NSInteger selectedFps = [self selectFpsForFormat:selectedFormat];


### PR DESCRIPTION
If RTCVideoView with opened _localRenderer placed at root Widget, after hot restarting application was crashed with error:

*** Assertion failure in -[RTCCameraVideoCapturer dealloc], ../../sdk/objc/components/capturer/RTCCameraVideoCapturer.m:113
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Session was still running in RTCCameraVideoCapturer dealloc. Forgot to call stopCapture?'