### PR TITLE
Add library module ProGuard configuration file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,7 @@ android {
     defaultConfig {
         minSdkVersion 18
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     lintOptions {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,3 @@
+# Flutter WebRTC
+-keep class com.cloudwebrtc.webrtc.** { *; }
+-keep class org.webrtc.** { *; }


### PR DESCRIPTION
It seems that instead of manually adding necessary for Flutter WebRTC ProGuard rules (as was suggested in [this comment](https://github.com/cloudwebrtc/flutter-webrtc/issues/205#issuecomment-601541102)), they could be added automatically with [library module ProGuard configuration file](https://developer.android.com/studio/projects/android-library) (and as result fix #205).