### PR TITLE
Fix problem when enabling and disabling remote track doesn't work

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -1145,7 +1145,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
   }
 
   public void mediaStreamTrackSetEnabled(final String id, final boolean enabled) {
-    MediaStreamTrack track = localTracks.get(id);
+    MediaStreamTrack track = getTrackForId(id);
 
     if (track == null) {
       Log.d(TAG, "mediaStreamTrackSetEnabled() track is null");

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -379,7 +379,7 @@
         NSDictionary* argsMap = call.arguments;
         NSString* trackId = argsMap[@"trackId"];
         NSNumber* enabled = argsMap[@"enabled"];
-        RTCMediaStreamTrack *track = self.localTracks[trackId];
+        RTCMediaStreamTrack *track = [self trackForId: trackId];
         if(track != nil){
             track.isEnabled = enabled.boolValue;
         }


### PR DESCRIPTION
This PR suggests a solution to the problem of enabling and disabling remote track. 

The Android and iOS native code only execute enabling feature for local tracks and not remote tracks. It is therefore impossible for the user to mute another speaker for himself. The same report describing this problem can be found in #174.

My suggestion is to avoid direct access to `localTracks` and use overall `getTrackForId ` method for android and `trackForId ` for iOS instead. If you find this helpful, I can create a PR with those changes. Just let me know 😀.

Another problem that not relates to this PR. After establishing the connection between iOS and Android devices the Android device can send and receive audio data, but the iOS device can only receive audio data. There is no indicator of using the microphone on it. Calling `enableSpeakerphone` after 10 seconds turns the microphone on and iOS device starts sending data. The strange thing is that I have called it before while creating a local stream by using `getUserMedia`, but only Android device works. Do you have any idea what causes this bug? During debugging I see that category property of AVAudioSession is `AVAudioSessionCategorySoloAmbient`, but I am not sure whether it leads to this problem. 🙁

Pseudo code:
```
// Full input and output in Android, but not for iOS (only output)
createLocalStream() {
    MediaStream stream = await navigator.mediaDevices.getUserMedia(mediaConstraints);
    stream.getAudioTracks()[0].setMicrophoneMute(initialVoiceMute);
    stream.getAudioTracks()[0].enableSpeakerphone(true);
}

// Adding this extra line enables microphone on IOS.
peerConnection!.onConnectionState = (state) {
   if (state == RTCPeerConnectionState.RTCPeerConnectionStateConnected) {
      localStream.getAudioTracks()[0].enableSpeakerphone(false);
   }
};
```



 