### PR TITLE
进行pc->CreateDataChannel(label.c_str(), &init);调用后，init中保存的id会被修改，这样就会…

### DIFF
--- a/windows/src/flutter_data_channel.cc
+++ b/windows/src/flutter_data_channel.cc
@@ -39,7 +39,7 @@ void FlutterDataChannel::CreateDataChannel(
 
   RTCDataChannelInit init;
   init.id = GetValue<int>(dataChannelDict.find(EncodableValue("id"))->second);
-
+  int _id = init.id;
   base_->lock();
   if (base_->data_channel_observers_.find( init.id) !=
       base_->data_channel_observers_.end()) {
@@ -77,9 +77,8 @@ void FlutterDataChannel::CreateDataChannel(
   scoped_refptr<RTCDataChannel> data_channel =
       pc->CreateDataChannel(label.c_str(), &init);
 
-
-  std::string event_channel = "FlutterWebRTC/dataChannelEvent" +
-                              peerConnectionId + std::to_string(init.id);
+  
+  std::string event_channel = "FlutterWebRTC/dataChannelEvent" + peerConnectionId + std::to_string(_id);
 
   std::unique_ptr<FlutterRTCDataChannelObserver> observer(
       new FlutterRTCDataChannelObserver(data_channel, base_->messenger_,


### PR DESCRIPTION
…与Flutter端使用的event_channel名称不一致。