### PR TITLE
Wait for capturer to stop

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -359,13 +359,17 @@
         NSDictionary* argsMap = call.arguments;
         NSString* streamId = argsMap[@"streamId"];
         RTCMediaStream *stream = self.localStreams[streamId];
+        BOOL shouldCallResult = YES;
         if (stream) {
             for (RTCVideoTrack *track in stream.videoTracks) {
                 [self.localTracks removeObjectForKey:track.trackId];
                 RTCVideoTrack *videoTrack = (RTCVideoTrack *)track;
                 RTCVideoSource *source = videoTrack.source;
                 if(source){
-                    [self.videoCapturer stopCapture];
+                    shouldCallResult = NO;
+                    [self.videoCapturer stopCaptureWithCompletionHandler:^{
+                      result(nil);
+                    }];
                     self.videoCapturer = nil;
                 }
             }
@@ -374,7 +378,10 @@
             }
             [self.localStreams removeObjectForKey:streamId];
         }
-        result(nil);
+        if (shouldCallResult) {
+          // do not call if will be called in stopCapturer above.
+          result(nil);
+        }
     } else if ([@"mediaStreamTrackSetEnable" isEqualToString:call.method]){
         NSDictionary* argsMap = call.arguments;
         NSString* trackId = argsMap[@"trackId"];


### PR DESCRIPTION
awaiting for `MediaStreamTrack.dispose()` returns immediately without fully waiting for the capturer to stop.

This should fix it.