### PR TITLE
Fix screen capture orientation for landscape-native devices

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
@@ -15,6 +15,7 @@ import android.view.Surface;
 import android.view.WindowManager;
 import android.app.Activity;
 import android.hardware.display.DisplayManager;
+import android.util.DisplayMetrics;
 import android.hardware.display.VirtualDisplay;
 import android.media.projection.MediaProjectionManager;
 import android.os.Looper;
@@ -76,9 +77,11 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
     }
 
     private boolean isDeviceOrientationPortrait() {
-        final int surfaceRotation = windowManager.getDefaultDisplay().getRotation();
-
-        return surfaceRotation != Surface.ROTATION_90 && surfaceRotation != Surface.ROTATION_270;
+        final Display display = windowManager.getDefaultDisplay();
+        final DisplayMetrics metrics = new DisplayMetrics();
+        display.getRealMetrics(metrics);
+        
+        return metrics.heightPixels > metrics.widthPixels;
     }
 
 


### PR DESCRIPTION
## Description
Fix orientation detection for devices where natural orientation is landscape.

## Related Issue
Fixes #1852 

## Changes
- Replace rotation-based detection with dimension-based detection in `OrientationAwareScreenCapturer.java`
- Add `DisplayMetrics` import
- Use actual display dimensions instead of assuming rotation meanings

## Testing
- [x] Tested on embedded device with 1280x800 landscape display
- [x] Verified virtual display now creates with correct dimensions (1280x800)
- [x] Maintains compatibility with standard portrait devices

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings