### PR TITLE
Fix audio session output port override for speaker toggle

### DIFF
--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -93,7 +93,7 @@
                                         AVAudioSessionCategoryOptionAllowBluetooth
                                   error:&error];
 
-    success = [session overrideOutputAudioPort:kAudioSessionProperty_OverrideAudioRoute
+    success = [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker
                                          error:&error];
     if (!success)
       NSLog(@"setSpeakerphoneOn: Port override failed due to: %@", error);


### PR DESCRIPTION
This pull request makes a targeted update to the `setSpeakerphoneOn:` method in `AudioUtils.m`, improving how the speakerphone audio route is overridden. The change replaces a deprecated or incorrect constant with the correct `AVAudioSessionPortOverrideSpeaker` value, ensuring compatibility and correctness.

- Audio routing update:
  * Updated the call to `overrideOutputAudioPort` to use `AVAudioSessionPortOverrideSpeaker` instead of `kAudioSessionProperty_OverrideAudioRoute` in the `setSpeakerphoneOn:` method in `AudioUtils.m`.