### PR TITLE
fix(macos): use CoreAudio ADM to prevent screen share crash

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -13,7 +13,7 @@
 @class FlutterRTCMediaRecorder;
 @class AudioManager;
 
-void postEvent(FlutterEventSink _Nonnull sink, id _Nullable event);
+void postEvent(FlutterEventSink _Nullable sink, id _Nullable event);
 
 typedef void (^CompletionHandler)(void);
 


### PR DESCRIPTION
## Summary
Switches from AVAudioEngine ADM to CoreAudio ADM on macOS to fix a crash when toggling the microphone during screen share.

## Problem
On macOS, when screen sharing with system audio, toggling the microphone causes this crash:

```
AVAudioIONodeImpl::SetOutputFormat: required condition is false: format.sampleRate == hwFormat.sampleRate
```

AVAudioEngine struggles to handle the format changes when both screen share audio and microphone audio are active simultaneously.

## Solution
Use CoreAudio ADM (value `0`) instead of `RTCAudioDeviceModuleTypeAudioEngine`. CoreAudio handles multiple audio sources without the format conflicts that cause the crash.

Also added a null check to `postEvent` since the eventSink can be nil during rapid screen share state transitions.

## Testing
- Start screen share with audio on macOS
- Toggle mic on/off during screen share
- Confirmed no crash and mic audio works correctly

