### PR TITLE
fix(ios): use transient port override for speaker toggle with CallKit

### DIFF
--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -107,23 +107,28 @@
   [session lockForConfiguration];
   NSError* error = nil;
   [session setMode:config.mode error:&error];
+  // Do NOT use DefaultToSpeaker — it is a persistent category option that
+  // prevents CallKit from toggling the speaker off via overrideOutputAudioPort.
+  // See Apple QA1754 for the difference between DefaultToSpeaker and PortOverrideSpeaker.
   BOOL success = [session setCategory:config.category
                           withOptions:AVAudioSessionCategoryOptionAllowAirPlay |
                                       AVAudioSessionCategoryOptionAllowBluetoothA2DP |
-                                      AVAudioSessionCategoryOptionAllowBluetooth |
-                                      AVAudioSessionCategoryOptionDefaultToSpeaker
+                                      AVAudioSessionCategoryOptionAllowBluetooth
                                 error:&error];
 
-  success = [session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None
+  // Use AVAudioSessionPortOverrideSpeaker (transient override) instead of
+  // DefaultToSpeaker (persistent category option). CallKit can undo this
+  // with overrideOutputAudioPort(.none).
+  success = [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker
                                         error:&error];
   if (!success)
     NSLog(@"setSpeakerphoneOnButPreferBluetooth: Port override failed due to: %@", error);
-
-  success = [session setActive:YES error:&error];
-  if (!success)
-    NSLog(@"setSpeakerphoneOnButPreferBluetooth: Audio session override failed: %@", error);
   else
-    NSLog(@"AudioSession override with bluetooth preference via setSpeakerphoneOnButPreferBluetooth successfull ");
+    NSLog(@"setSpeakerphoneOnButPreferBluetooth: Port override to Speaker OK");
+
+  // Do NOT call setActive:YES here. During a CallKit call the audio session
+  // is already active. Re-activating resets the transient port override,
+  // moving audio back from Speaker to Receiver (reason=3 categoryChange).
   [session unlockForConfiguration];
 }
 


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                         
  `setSpeakerphoneOnButPreferBluetooth` uses `DefaultToSpeaker` as a          
  category option combined with `overrideOutputAudioPort(.none)`. This is
  a persistent category option that conflicts with CallKit's speaker
  management — CallKit cannot toggle the speaker off via
  `overrideOutputAudioPort(.none)` when `DefaultToSpeaker` is set.

  Additionally, `setActive:YES` is called while CallKit already has the
  audio session active. This triggers a category change (route change
  reason=3) that resets the transient port override, routing audio back
  from Speaker to Receiver.

  Together these issues cause speaker toggle to be unreliable or
  non-functional in CallKit-managed VoIP calls.

  ## Root cause
  Apple distinguishes between two speaker mechanisms (see Apple QA1754):
  - `DefaultToSpeaker`: persistent category option — stays active until
    the category is reconfigured. Conflicts with CallKit's
    `overrideOutputAudioPort(.none)`.
  - `AVAudioSessionPortOverrideSpeaker`: transient override — can be
    undone by CallKit or the system at any time.

  ## Fix
  - Replaced `DefaultToSpeaker` category option with
    `AVAudioSessionPortOverrideSpeaker` (transient override)
  - Removed `setActive:YES` — the audio session is already active during
    a CallKit call, re-activating it resets the transient override