### PR TITLE
fix(android): avoid Turkish locale issue in DegradationPreference.valueOf

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.webrtc.AudioTrack;
@@ -781,7 +782,7 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
 
     String degradationPreference = (String) newParameters.get("degradationPreference");
     if (degradationPreference != null) {
-      parameters.degradationPreference = RtpParameters.DegradationPreference.valueOf(degradationPreference.toUpperCase().replace("-", "_"));
+      parameters.degradationPreference = RtpParameters.DegradationPreference.valueOf(degradationPreference.toUpperCase(Locale.US).replace("-", "_"));
     }
 
     for (Map<String, Object> encoding : encodings) {


### PR DESCRIPTION
**Problem**
When the device locale is Turkish, toUpperCase() converts "i" to "İ", producing `"MAİNTAİN_RESOLUTİON"`.
This causes valueOf to fail because the enum only contains the ASCII constant MAINTAIN_RESOLUTION.

**Fix**
Replaced toUpperCase() with toUpperCase(Locale.US) to ensure locale-independent enum conversion.

**Test**
Verified that the exception no longer occurs on Turkish locale.
No behavior change on other locales.
