### PR TITLE
fix(ios): use AVAudioEngine on iOS (#2007)

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -306,8 +306,19 @@ static FlutterWebRTCPlugin *sharedSingleton;
         // AVAudioEngine crashes when screen share audio and microphone coexist due to
         // format conflicts in AVAudioIONodeImpl::SetOutputFormat
         // See: https://github.com/flutter-webrtc/flutter-webrtc/issues/1986
+        //
+        // Initializing the Audio Device Module Type with 0 leads to a crash on iOS
+        // in case NSMicrophoneUsageDescription is missing in Info.plist file
+        // (consumer/viewer only stream without microphone)
+        // this condition uses AVAudioEngine for iOS while preserving the fix above for macOS
+        // See: https://github.com/flutter-webrtc/flutter-webrtc/issues/2007
+#if TARGET_OS_IPHONE
+        RTCAudioDeviceModuleType audioDeviceModuleType = RTCAudioDeviceModuleTypeAudioEngine;
+#else
+        RTCAudioDeviceModuleType audioDeviceModuleType = 0;
+#endif
         _peerConnectionFactory =
-            [[RTCPeerConnectionFactory alloc] initWithAudioDeviceModuleType:0
+            [[RTCPeerConnectionFactory alloc] initWithAudioDeviceModuleType:audioDeviceModuleType
                                                       bypassVoiceProcessing:bypassVoiceProcessing
                                                              encoderFactory:simulcastFactory
                                                              decoderFactory:decoderFactory


### PR DESCRIPTION
Fix for #2007

Use `AVAudioEngine` on iOS to prevent unnecessary microphone permission request

Issue introduced in https://github.com/flutter-webrtc/flutter-webrtc/commit/ed0a88aa42a682a53ce424a211a43da5b173d086

Switches to RTCAudioDeviceModuleTypeAudioEngine on iOS while keeping CoreAudio ADM (type 0) on macOS for the screen share crash fix #1990

Fixes a crash when `NSMicrophoneUsageDescription` is missing in `Info.plist` file.

Fixes microphone permission being requested on iOS for receive-only WebRTC connections.