### PR TITLE
fix(android): prevent CameraAccessException on concurrent video calls

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -889,6 +889,7 @@ public class GetUserMediaImpl {
         mediaStream.addTrack(track);
         stateProvider.putLocalTrack(track.id(), new LocalVideoTrack(track));
 
+        // TODO: extract into a helper method - same block (enabled, id, kind, label, readyState, remote) repeated in getUserAudio() and getUserVideo()
         ConstraintsMap trackParams = new ConstraintsMap();
         trackParams.putBoolean("enabled", track.enabled());
         trackParams.putString("id", track.id());
@@ -897,6 +898,7 @@ public class GetUserMediaImpl {
         trackParams.putString("readyState", track.state().toString());
         trackParams.putBoolean("remote", false);
 
+        // TODO: extract into a helper method - same block (deviceId, kind, width, height, frameRate) repeated in getUserVideo()
         ConstraintsMap settings = new ConstraintsMap();
         settings.putString("deviceId", primary.cameraName != null ? primary.cameraName : "");
         settings.putString("kind", "videoinput");

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -827,6 +827,7 @@ public class GetUserMediaImpl {
 
         info.cameraEventsHandler = cameraEventsHandler;
         info.videoSource = videoSource;
+        info.facingMode = facingMode;
         videoCapturer.startCapture(targetWidth, targetHeight, targetFps);
 
         cameraEventsHandler.waitForCameraOpen();
@@ -882,6 +883,7 @@ public class GetUserMediaImpl {
         sharedInfo.height = primary.height;
         sharedInfo.fps = primary.fps;
         sharedInfo.cameraName = primary.cameraName;
+        sharedInfo.facingMode = primary.facingMode;
         sharedInfo.isScreenCapture = false;
         sharedInfo.capturer = null;
         sharedInfo.videoSource = primary.videoSource;
@@ -908,6 +910,7 @@ public class GetUserMediaImpl {
         settings.putInt("width", primary.width);
         settings.putInt("height", primary.height);
         settings.putInt("frameRate", primary.fps);
+        if (primary.facingMode != null) settings.putString("facingMode", primary.facingMode);
         trackParams.putMap("settings", settings.toMap());
 
         Log.d(TAG, "buildSharedVideoTrack: created shared track " + trackId
@@ -1132,6 +1135,8 @@ public class GetUserMediaImpl {
          * Points to the trackId of the primary capturer entry. Null for primary entries.
          */
         public String primaryTrackId;
+        /** Facing mode resolved at camera open time: "user", "environment", or null if unknown. */
+        public String facingMode;
     }
 
     public VideoCapturerInfoEx getCapturerInfo(String trackId) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -703,32 +703,6 @@ public class GetUserMediaImpl {
 
         Log.i(TAG, "getUserMedia(video): " + videoConstraintsMap);
 
-        // If a camera is already active, reuse its VideoSource instead of opening a second
-        // Camera2 session for the same camera device.
-        //
-        // When the same camera is opened twice from one process, cameraserver "steals" it from
-        // the first client: the first CaptureSession receives onDisconnected(), which internally
-        // calls close() -> stopRepeating() -> cancelRequest(). The camera HAL returns ENOSYS
-        // (-38 / "Function not implemented") for cancelRequest when the pipeline is already being
-        // torn down, and Android's CameraCaptureSessionImpl does not handle that error - it
-        // propagates as CameraAccessException(CAMERA_ERROR=3).
-        //
-        // This is reproducible on stock AOSP (Pixel) and any Android device: it is a bug in the
-        // Android Camera2 framework (CameraCaptureSessionImpl.onDisconnected does not guard
-        // against ENOSYS from cancelRequest), not an OEM-specific issue.
-        // NOTE: reuses the first active primary camera entry regardless of camera ID (front/back).
-        // This is intentional for the current use case where all calls share the same camera.
-        // If a future use case requires different calls to use different cameras simultaneously,
-        // add a cameraName check here before reusing.
-        for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
-            VideoCapturerInfoEx existing = entry.getValue();
-            if (!existing.isScreenCapture && existing.primaryTrackId == null && existing.videoSource != null) {
-                Log.w(TAG, "getUserMedia(video): camera already active (track=" + entry.getKey()
-                        + "), reusing VideoSource to prevent concurrent camera access");
-                return buildSharedVideoTrack(existing, entry.getKey(), mediaStream);
-            }
-        }
-
         // NOTE: to support Camera2, the device should:
         //   1. Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
         //   2. all camera support level should greater than LEGACY
@@ -748,6 +722,31 @@ public class GetUserMediaImpl {
         String facingMode = getFacingMode(videoConstraintsMap);
         isFacing = facingMode == null || !facingMode.equals("environment");
         String deviceId = getSourceIdConstraint(videoConstraintsMap);
+
+        // If a camera is already active for the same facing direction, reuse its VideoSource
+        // instead of opening a second Camera2 session for the same camera device.
+        //
+        // When the same camera is opened twice from one process, cameraserver "steals" it from
+        // the first client: the first CaptureSession receives onDisconnected(), which internally
+        // calls close() -> stopRepeating() -> cancelRequest(). The camera HAL returns ENOSYS
+        // (-38 / "Function not implemented") for cancelRequest when the pipeline is already being
+        // torn down, and Android's CameraCaptureSessionImpl does not handle that error - it
+        // propagates as CameraAccessException(CAMERA_ERROR=3).
+        //
+        // This is reproducible on stock AOSP (Pixel) and any Android device: it is a bug in the
+        // Android Camera2 framework (CameraCaptureSessionImpl.onDisconnected does not guard
+        // against ENOSYS from cancelRequest), not an OEM-specific issue.
+        final boolean requestedFacingFront = isFacing;
+        for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
+            VideoCapturerInfoEx existing = entry.getValue();
+            if (!existing.isScreenCapture && existing.primaryTrackId == null
+                    && existing.videoSource != null && existing.cameraName != null
+                    && cameraEnumerator.isFrontFacing(existing.cameraName) == requestedFacingFront) {
+                Log.w(TAG, "getUserMedia(video): camera already active (track=" + entry.getKey()
+                        + "), reusing VideoSource to prevent concurrent camera access");
+                return buildSharedVideoTrack(existing, entry.getKey(), mediaStream);
+            }
+        }
         CameraEventsHandler cameraEventsHandler = new CameraEventsHandler();
         Pair<String, VideoCapturer> result = createVideoCapturer(cameraEnumerator, isFacing, deviceId, cameraEventsHandler);
 

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -703,6 +703,28 @@ public class GetUserMediaImpl {
 
         Log.i(TAG, "getUserMedia(video): " + videoConstraintsMap);
 
+        // If a camera is already active, reuse its VideoSource instead of opening a second
+        // Camera2 session for the same camera device.
+        //
+        // When the same camera is opened twice from one process, cameraserver "steals" it from
+        // the first client: the first CaptureSession receives onDisconnected(), which internally
+        // calls close() -> stopRepeating() -> cancelRequest(). The camera HAL returns ENOSYS
+        // (-38 / "Function not implemented") for cancelRequest when the pipeline is already being
+        // torn down, and Android's CameraCaptureSessionImpl does not handle that error - it
+        // propagates as CameraAccessException(CAMERA_ERROR=3).
+        //
+        // This is reproducible on stock AOSP (Pixel) and any Android device: it is a bug in the
+        // Android Camera2 framework (CameraCaptureSessionImpl.onDisconnected does not guard
+        // against ENOSYS from cancelRequest), not an OEM-specific issue.
+        for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
+            VideoCapturerInfoEx existing = entry.getValue();
+            if (!existing.isScreenCapture && existing.primaryTrackId == null && existing.videoSource != null) {
+                Log.w(TAG, "getUserMedia(video): camera already active (track=" + entry.getKey()
+                        + "), reusing VideoSource to prevent concurrent camera access");
+                return buildSharedVideoTrack(existing, entry.getKey(), mediaStream);
+            }
+        }
+
         // NOTE: to support Camera2, the device should:
         //   1. Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
         //   2. all camera support level should greater than LEGACY
@@ -798,6 +820,7 @@ public class GetUserMediaImpl {
         }
 
         info.cameraEventsHandler = cameraEventsHandler;
+        info.videoSource = videoSource;
         videoCapturer.startCapture(targetWidth, targetHeight, targetFps);
 
         cameraEventsHandler.waitForCameraOpen();
@@ -838,9 +861,97 @@ public class GetUserMediaImpl {
         return trackParams;
     }
 
+    /**
+     * Creates a secondary VideoTrack that shares the already-open camera session of {@code primary}.
+     * No new camera is opened; a new VideoTrack is simply derived from the existing VideoSource.
+     * The returned entry in mVideoCapturers has primaryTrackId set so that removeVideoCapturer
+     * knows not to stop the underlying capturer when only this secondary track is removed.
+     */
+    private ConstraintsMap buildSharedVideoTrack(VideoCapturerInfoEx primary, String primaryTrackId, MediaStream mediaStream) {
+        PeerConnectionFactory pcFactory = stateProvider.getPeerConnectionFactory();
+        String trackId = stateProvider.getNextTrackUUID();
+
+        VideoCapturerInfoEx sharedInfo = new VideoCapturerInfoEx();
+        sharedInfo.width = primary.width;
+        sharedInfo.height = primary.height;
+        sharedInfo.fps = primary.fps;
+        sharedInfo.cameraName = primary.cameraName;
+        sharedInfo.isScreenCapture = false;
+        sharedInfo.capturer = null;
+        sharedInfo.videoSource = primary.videoSource;
+        sharedInfo.primaryTrackId = primaryTrackId;
+        mVideoCapturers.put(trackId, sharedInfo);
+
+        VideoTrack track = pcFactory.createVideoTrack(trackId, primary.videoSource);
+        mediaStream.addTrack(track);
+        stateProvider.putLocalTrack(track.id(), new LocalVideoTrack(track));
+
+        ConstraintsMap trackParams = new ConstraintsMap();
+        trackParams.putBoolean("enabled", track.enabled());
+        trackParams.putString("id", track.id());
+        trackParams.putString("kind", "video");
+        trackParams.putString("label", track.id());
+        trackParams.putString("readyState", track.state().toString());
+        trackParams.putBoolean("remote", false);
+
+        ConstraintsMap settings = new ConstraintsMap();
+        settings.putString("deviceId", primary.cameraName != null ? primary.cameraName : "");
+        settings.putString("kind", "videoinput");
+        settings.putInt("width", primary.width);
+        settings.putInt("height", primary.height);
+        settings.putInt("frameRate", primary.fps);
+        trackParams.putMap("settings", settings.toMap());
+
+        Log.d(TAG, "buildSharedVideoTrack: created shared track " + trackId
+                + " from primary " + primaryTrackId);
+        return trackParams;
+    }
+
     void removeVideoCapturer(String id) {
         VideoCapturerInfoEx info = mVideoCapturers.get(id);
-        if (info != null) {
+        if (info == null) return;
+
+        if (info.primaryTrackId != null) {
+            // Shared (secondary) track - the underlying capturer belongs to the primary.
+            // Just unregister this entry; the capturer keeps running.
+            Log.d(TAG, "removeVideoCapturer: removing shared track " + id
+                    + " (primary=" + info.primaryTrackId + ")");
+            mVideoCapturers.remove(id);
+            return;
+        }
+
+        // Primary capturer being removed. Check whether any shared track still references it.
+        String newPrimaryId = null;
+        for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
+            if (id.equals(entry.getValue().primaryTrackId)) {
+                newPrimaryId = entry.getKey();
+                break;
+            }
+        }
+
+        if (newPrimaryId != null) {
+            // At least one shared track is still alive. Promote it to primary so the
+            // capturer keeps running and remaining shared tracks stay valid.
+            VideoCapturerInfoEx promoted = mVideoCapturers.get(newPrimaryId);
+            promoted.primaryTrackId = null;
+            promoted.capturer = info.capturer;
+            promoted.cameraEventsHandler = info.cameraEventsHandler;
+
+            SurfaceTextureHelper helper = mSurfaceTextureHelpers.remove(id);
+            if (helper != null) mSurfaceTextureHelpers.put(newPrimaryId, helper);
+
+            // Re-point every remaining shared track to the new primary.
+            for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
+                if (id.equals(entry.getValue().primaryTrackId)) {
+                    entry.getValue().primaryTrackId = newPrimaryId;
+                }
+            }
+
+            mVideoCapturers.remove(id);
+            Log.d(TAG, "removeVideoCapturer: promoted " + newPrimaryId
+                    + " to primary capturer (was " + id + ")");
+        } else {
+            // No shared tracks - stop and dispose the capturer normally.
             try {
                 info.capturer.stopCapture();
                 if (info.cameraEventsHandler != null) {
@@ -904,7 +1015,17 @@ public class GetUserMediaImpl {
     }
 
     void switchCamera(String id, Result result) {
-        VideoCapturer videoCapturer = mVideoCapturers.get(id).capturer;
+        VideoCapturerInfoEx info = mVideoCapturers.get(id);
+        if (info == null) {
+            resultError("switchCamera", "Video capturer not found for id: " + id, result);
+            return;
+        }
+        // Shared tracks have capturer=null - resolve to the primary entry that owns the capturer.
+        if (info.primaryTrackId != null) {
+            VideoCapturerInfoEx primary = mVideoCapturers.get(info.primaryTrackId);
+            if (primary != null) info = primary;
+        }
+        VideoCapturer videoCapturer = info.capturer;
         if (videoCapturer == null) {
             resultError("switchCamera", "Video capturer not found for id: " + id, result);
             return;
@@ -982,12 +1103,10 @@ public class GetUserMediaImpl {
 
     public void reStartCamera(IsCameraEnabled getCameraId) {
         for (Map.Entry<String, VideoCapturerInfoEx> item : mVideoCapturers.entrySet()) {
-            if (!item.getValue().isScreenCapture && getCameraId.isEnabled(item.getKey())) {
-                item.getValue().capturer.startCapture(
-                        item.getValue().width,
-                        item.getValue().height,
-                        item.getValue().fps
-                );
+            VideoCapturerInfoEx info = item.getValue();
+            // Skip screen captures and shared (secondary) tracks - they have no capturer.
+            if (!info.isScreenCapture && info.primaryTrackId == null && getCameraId.isEnabled(item.getKey())) {
+                info.capturer.startCapture(info.width, info.height, info.fps);
             }
         }
     }
@@ -998,6 +1117,13 @@ public class GetUserMediaImpl {
 
     public static class VideoCapturerInfoEx extends VideoCapturerInfo  {
         public CameraEventsHandler cameraEventsHandler;
+        /** The VideoSource used to create the VideoTrack for this capturer. */
+        public VideoSource videoSource;
+        /**
+         * Non-null when this is a shared (secondary) track that reuses an existing camera session.
+         * Points to the trackId of the primary capturer entry. Null for primary entries.
+         */
+        public String primaryTrackId;
     }
 
     public VideoCapturerInfoEx getCapturerInfo(String trackId) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -739,9 +739,12 @@ public class GetUserMediaImpl {
         final boolean requestedFacingFront = isFacing;
         for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
             VideoCapturerInfoEx existing = entry.getValue();
+            boolean sameCamera = (deviceId != null && !deviceId.isEmpty())
+                    ? existing.cameraName.equals(deviceId)
+                    : cameraEnumerator.isFrontFacing(existing.cameraName) == requestedFacingFront;
             if (!existing.isScreenCapture && existing.primaryTrackId == null
                     && existing.videoSource != null && existing.cameraName != null
-                    && cameraEnumerator.isFrontFacing(existing.cameraName) == requestedFacingFront) {
+                    && sameCamera) {
                 Log.w(TAG, "getUserMedia(video): camera already active (track=" + entry.getKey()
                         + "), reusing VideoSource to prevent concurrent camera access");
                 return buildSharedVideoTrack(existing, entry.getKey(), mediaStream);

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -716,6 +716,10 @@ public class GetUserMediaImpl {
         // This is reproducible on stock AOSP (Pixel) and any Android device: it is a bug in the
         // Android Camera2 framework (CameraCaptureSessionImpl.onDisconnected does not guard
         // against ENOSYS from cancelRequest), not an OEM-specific issue.
+        // NOTE: reuses the first active primary camera entry regardless of camera ID (front/back).
+        // This is intentional for the current use case where all calls share the same camera.
+        // If a future use case requires different calls to use different cameras simultaneously,
+        // add a cameraName check here before reusing.
         for (Map.Entry<String, VideoCapturerInfoEx> entry : mVideoCapturers.entrySet()) {
             VideoCapturerInfoEx existing = entry.getValue();
             if (!existing.isScreenCapture && existing.primaryTrackId == null && existing.videoSource != null) {


### PR DESCRIPTION
### Context

On Android, opening the same physical camera device twice from one process triggers the Camera2
winner-takes-all rule: `cameraserver` disconnects the first session synchronously at the HAL
level, then delivers `onDisconnected` asynchronously - after the HAL pipeline is already
destroyed.

`CameraCaptureSessionImpl.onDisconnected` (line 805) unconditionally calls `close()` (line 579)
-> `stopRepeating()` (line 1448) -> `cancelRequest()`, which returns `ENOSYS (-38)` because the
pipeline no longer exists. This propagates as `CameraAccessException: CAMERA_ERROR (3)`.

A concrete scenario: two consecutive incoming video calls - call 1 active with camera held, call
2 arriving a few seconds later. The second `getUserMedia(video)` requests the same camera ID
while call 1's session is still live.

**Reproducible on any Android device including stock Pixel (AOSP) - not an OEM-specific issue.**
Confirmed on Samsung Galaxy Cover 5, Xiaomi, and Pixel.

---

### What this PR covers

#### Single datasource + fan-out (`getUserVideo`)

Before opening a new camera, `getUserVideo()` scans `mVideoCapturers` for an existing primary
entry for the same camera. If found, it returns a shared `VideoTrack` derived from the existing
`VideoSource` via `buildSharedVideoTrack()` - no `startCapture()`, no new camera connect.
`cameraserver` sees a single client; `onDisconnected` is never triggered; `ENOSYS` is
structurally impossible.

Camera matching: when the caller passes an explicit `deviceId`, the check matches by exact
`cameraName == deviceId` (handles multi-camera devices with multiple back cameras). Without
`deviceId`, falls back to facing-direction match via `isFrontFacing`.

#### New `buildSharedVideoTrack()` method

Creates a secondary `VideoTrack` from the existing `VideoSource` of a primary entry. The new
`VideoCapturerInfoEx` entry has `capturer = null` and `primaryTrackId` pointing to the primary,
so the rest of the lifecycle code knows it does not own the camera session. Returns the same
track settings structure as the primary path, including `facingMode`.

#### `removeVideoCapturer()` - shared track lifecycle

Reworked to handle three cases:

1. **Shared track removed** - entry is unregistered; the underlying capturer keeps running.
2. **Primary removed while shared tracks exist** - one shared track is promoted to primary
   (receives `capturer`, `cameraEventsHandler`, `SurfaceTextureHelper`); remaining shared tracks
   are re-pointed to the new primary. Camera keeps running.
3. **Primary removed, no shared tracks** - capturer is stopped and disposed normally (existing
   behavior).

#### `switchCamera()` - shared track support

Shared entries have `capturer = null`. `switchCamera` now resolves to the primary entry via
`primaryTrackId` before accessing `capturer`, and handles a missing entry with an explicit error
instead of a NullPointerException.

#### `reStartCamera()` - skip shared entries

Shared entries have no `capturer`. `reStartCamera` now skips entries where `primaryTrackId` is
set, avoiding a NullPointerException when the camera is re-opened after interruption.

#### `VideoCapturerInfoEx` - new fields

| Field | Purpose |
|---|---|
| `videoSource` | The `VideoSource` backing this track; shared across primary and all its shared entries |
| `primaryTrackId` | Non-null on shared entries; points to the primary entry that owns the capturer |
| `facingMode` | "user" / "environment" / null; resolved at open time, propagated to shared entries |

---

### Files changed

| File | Changes |
|---|---|
| `android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java` | reuse check in getUserVideo, buildSharedVideoTrack (new), removeVideoCapturer lifecycle, switchCamera primary resolution, reStartCamera shared-track skip, VideoCapturerInfoEx fields |

---

### Logcat (expected output with reuse active)

```
W  getUserMedia(video): camera already active (track=b5435b4b-...), reusing VideoSource to prevent concurrent camera access
D  buildSharedVideoTrack: created shared track 39f26460-... from primary b5435b4b-...
```

No `CameraAccessException`, no `ENOSYS (-38)`. WebRTC ICE flow proceeds normally.
`switchCamera` works on both lines.