### PR TITLE
fix(ios): stabilize WebRTC audio session recovery and output device routing

### DIFF
--- a/common/darwin/Classes/AudioUtils.m
+++ b/common/darwin/Classes/AudioUtils.m
@@ -1,6 +1,7 @@
 #if TARGET_OS_IPHONE
 #import "AudioUtils.h"
 #import <AVFoundation/AVFoundation.h>
+#import <WebRTC/RTCLogging.h>
 
 @implementation AudioUtils
 
@@ -9,32 +10,39 @@
   // we also need to set default WebRTC audio configuration, since it may be activated after
   // this method is called
   RTCAudioSessionConfiguration* config = [RTCAudioSessionConfiguration webRTCConfiguration];
-  // require audio session to be either PlayAndRecord or MultiRoute
-  if (recording && session.category != AVAudioSessionCategoryPlayAndRecord &&
-      session.category != AVAudioSessionCategoryMultiRoute) {
+  if (recording) {
     config.category = AVAudioSessionCategoryPlayAndRecord;
+    config.mode = AVAudioSessionModeVoiceChat;
     config.categoryOptions =
         AVAudioSessionCategoryOptionAllowBluetooth |
         AVAudioSessionCategoryOptionAllowBluetoothA2DP |
         AVAudioSessionCategoryOptionAllowAirPlay;
 
-    [session lockForConfiguration];
-    NSError* error = nil;
-    bool success = [session setCategory:config.category withOptions:config.categoryOptions error:&error];
-    if (!success)
-      NSLog(@"ensureAudioSessionWithRecording[true]: setCategory failed due to: %@", error);
-    success = [session setMode:config.mode error:&error];
-    if (!success)
-      NSLog(@"ensureAudioSessionWithRecording[true]: setMode failed due to: %@", error);
-    [session unlockForConfiguration];
-  } else if (!recording && (session.category == AVAudioSessionCategoryAmbient ||
-                            session.category == AVAudioSessionCategorySoloAmbient)) {
+    BOOL isTargetCategory = [session.category isEqualToString:config.category];
+    BOOL isTargetMode = [session.mode isEqualToString:config.mode];
+    BOOL hasTargetOptions =
+        (session.categoryOptions & config.categoryOptions) == config.categoryOptions;
+    if (!isTargetCategory || !isTargetMode || !hasTargetOptions) {
+      [session lockForConfiguration];
+      NSError* error = nil;
+      BOOL success = [session setCategory:config.category
+                              withOptions:config.categoryOptions
+                                    error:&error];
+      if (!success)
+        RTCLog(@"ensureAudioSessionWithRecording[true]: setCategory failed due to: %@", error);
+      success = [session setMode:config.mode error:&error];
+      if (!success)
+        RTCLog(@"ensureAudioSessionWithRecording[true]: setMode failed due to: %@", error);
+      [session unlockForConfiguration];
+    }
+  } else if (!recording && ([session.category isEqualToString:AVAudioSessionCategoryAmbient] ||
+                            [session.category isEqualToString:AVAudioSessionCategorySoloAmbient])) {
     config.mode = AVAudioSessionModeDefault;
     [session lockForConfiguration];
     NSError* error = nil;
     bool success = [session setMode:config.mode error:&error];
     if (!success)
-      NSLog(@"ensureAudioSessionWithRecording[false]: setMode failed due to: %@", error);
+      RTCLog(@"ensureAudioSessionWithRecording[false]: setMode failed due to: %@", error);
     [session unlockForConfiguration];
   }
 }
@@ -65,8 +73,8 @@
   RTCAudioSession* session = [RTCAudioSession sharedInstance];
   RTCAudioSessionConfiguration* config = [RTCAudioSessionConfiguration webRTCConfiguration];
     
-  if(enable && config.category != AVAudioSessionCategoryPlayAndRecord) {
-    NSLog(@"setSpeakerphoneOn: Category option 'defaultToSpeaker' is only applicable with category 'playAndRecord', ignore.");
+  if (enable && ![config.category isEqualToString:AVAudioSessionCategoryPlayAndRecord]) {
+    RTCLog(@"setSpeakerphoneOn: Category option 'defaultToSpeaker' is only applicable with category 'playAndRecord', ignore.");
     return;
   }
 
@@ -80,10 +88,10 @@
                                         AVAudioSessionCategoryOptionAllowBluetooth
                                   error:&error];
 
-    success = [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None
-                                                 error:&error];
+    success = [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone
+                                         error:&error];
     if (!success)
-      NSLog(@"setSpeakerphoneOn: Port override failed due to: %@", error);
+      RTCLog(@"setSpeakerphoneOn: Port override failed due to: %@", error);
   } else {
     [session setMode:config.mode error:&error];
     BOOL success = [session setCategory:config.category
@@ -93,11 +101,14 @@
                                         AVAudioSessionCategoryOptionAllowBluetooth
                                   error:&error];
 
-    success = [session overrideOutputAudioPort:kAudioSessionProperty_OverrideAudioRoute
+    success = [session overrideOutputAudioPort:AVAudioSessionPortOverrideSpeaker
                                          error:&error];
     if (!success)
-      NSLog(@"setSpeakerphoneOn: Port override failed due to: %@", error);
+      RTCLog(@"setSpeakerphoneOn: Port override failed due to: %@", error);
   }
+  BOOL activeSuccess = [session setActive:YES error:&error];
+  if (!activeSuccess)
+    RTCLog(@"setSpeakerphoneOn: setActive failed due to: %@", error);
   [session unlockForConfiguration];
 }
 
@@ -114,16 +125,16 @@
                                       AVAudioSessionCategoryOptionDefaultToSpeaker
                                 error:&error];
 
-  success = [session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None
-                                        error:&error];
+  success = [session overrideOutputAudioPort:AVAudioSessionPortOverrideNone
+                                       error:&error];
   if (!success)
-    NSLog(@"setSpeakerphoneOnButPreferBluetooth: Port override failed due to: %@", error);
+    RTCLog(@"setSpeakerphoneOnButPreferBluetooth: Port override failed due to: %@", error);
 
   success = [session setActive:YES error:&error];
   if (!success)
-    NSLog(@"setSpeakerphoneOnButPreferBluetooth: Audio session override failed: %@", error);
+    RTCLog(@"setSpeakerphoneOnButPreferBluetooth: Audio session override failed: %@", error);
   else
-    NSLog(@"AudioSession override with bluetooth preference via setSpeakerphoneOnButPreferBluetooth successfull ");
+    RTCLog(@"AudioSession override with bluetooth preference via setSpeakerphoneOnButPreferBluetooth successfull ");
   [session unlockForConfiguration];
 }
 
@@ -134,9 +145,9 @@
   if ([session isActive]) {
     BOOL success = [session setActive:NO error:&error];
     if (!success)
-      NSLog(@"RTC Audio session deactive failed: %@", error);
+      RTCLog(@"RTC Audio session deactive failed: %@", error);
     else
-      NSLog(@"RTC AudioSession deactive is successful ");
+      RTCLog(@"RTC AudioSession deactive is successful ");
   }
   [session unlockForConfiguration];
 }

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -1,4 +1,5 @@
 #import <objc/runtime.h>
+#import <WebRTC/RTCLogging.h>
 #import "AudioUtils.h"
 #import "CameraUtils.h"
 #import "FlutterRTCFrameCapturer.h"
@@ -33,6 +34,10 @@
   return nil;
 }
 
+@end
+
+@interface FlutterWebRTCPlugin (TVoxRouteLogging)
+- (void)tvoxRouteLog:(NSString*)format, ...;
 @end
 
 @implementation FlutterWebRTCPlugin (RTCMediaStream)
@@ -793,18 +798,52 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
   }
 #endif
 #if TARGET_OS_IPHONE
+  NSString* normalized = [deviceId lowercaseString];
+  BOOL wantsSpeaker =
+      [normalized isEqualToString:@"speaker"] ||
+      [normalized isEqualToString:@"speakerphone"] ||
+      [normalized containsString:@"speaker"] ||
+      [normalized containsString:@"altoparlante"];
+  BOOL wantsReceiver =
+      [normalized isEqualToString:@"earpiece"] ||
+      [normalized isEqualToString:@"receiver"] ||
+      [normalized containsString:@"earpiece"] ||
+      [normalized containsString:@"receiver"] ||
+      [normalized containsString:@"ricevitore"];
   RTCAudioSession* session = [RTCAudioSession sharedInstance];
-  NSError* setCategoryError = nil;
+  NSString* outputBefore = session.currentRoute.outputs.firstObject.portType;
+  [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput requested=%@ normalized=%@ wantsSpeaker=%d wantsReceiver=%d outputBefore=%@",
+        deviceId,
+        normalized,
+        wantsSpeaker,
+        wantsReceiver,
+        outputBefore];
 
-  if ([deviceId isEqualToString:@"Speaker"]) {
-    [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_Speaker
-                                       error:&setCategoryError];
-  } else {
-    [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None
-                                       error:&setCategoryError];
+  if (wantsSpeaker) {
+    [AudioUtils setSpeakerphoneOn:YES];
+    NSString* outputAfter = [RTCAudioSession sharedInstance].currentRoute.outputs.firstObject.portType;
+    [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput applied speaker outputAfter=%@",
+          outputAfter];
+    result(nil);
+    return;
+  }
+  if (wantsReceiver) {
+    [AudioUtils setSpeakerphoneOn:NO];
+    NSString* outputAfter = [RTCAudioSession sharedInstance].currentRoute.outputs.firstObject.portType;
+    [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput applied receiver outputAfter=%@",
+          outputAfter];
+    result(nil);
+    return;
   }
 
+  // Fallback behavior: keep iOS default route selection for unknown/physical ids.
+  NSError* setCategoryError = nil;
+  [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None
+                                     error:&setCategoryError];
   if (setCategoryError == nil) {
+    NSString* outputAfter = [RTCAudioSession sharedInstance].currentRoute.outputs.firstObject.portType;
+    [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput fallback-none outputAfter=%@",
+          outputAfter];
     result(nil);
     return;
   }
@@ -814,6 +853,7 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
             message:[NSString
                         stringWithFormat:@"Error: %@", [setCategoryError localizedFailureReason]]
             details:nil]);
+  return;
 
 #endif
   result([FlutterError errorWithCode:@"selectAudioOutputFailed"

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -36,10 +36,6 @@
 
 @end
 
-@interface FlutterWebRTCPlugin (TVoxRouteLogging)
-- (void)tvoxRouteLog:(NSString*)format, ...;
-@end
-
 @implementation FlutterWebRTCPlugin (RTCMediaStream)
 
 /**
@@ -811,27 +807,14 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
       [normalized containsString:@"receiver"] ||
       [normalized containsString:@"ricevitore"];
   RTCAudioSession* session = [RTCAudioSession sharedInstance];
-  NSString* outputBefore = session.currentRoute.outputs.firstObject.portType;
-  [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput requested=%@ normalized=%@ wantsSpeaker=%d wantsReceiver=%d outputBefore=%@",
-        deviceId,
-        normalized,
-        wantsSpeaker,
-        wantsReceiver,
-        outputBefore];
 
   if (wantsSpeaker) {
     [AudioUtils setSpeakerphoneOn:YES];
-    NSString* outputAfter = [RTCAudioSession sharedInstance].currentRoute.outputs.firstObject.portType;
-    [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput applied speaker outputAfter=%@",
-          outputAfter];
     result(nil);
     return;
   }
   if (wantsReceiver) {
     [AudioUtils setSpeakerphoneOn:NO];
-    NSString* outputAfter = [RTCAudioSession sharedInstance].currentRoute.outputs.firstObject.portType;
-    [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput applied receiver outputAfter=%@",
-          outputAfter];
     result(nil);
     return;
   }
@@ -841,9 +824,6 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
   [session.session overrideOutputAudioPort:kAudioSessionOverrideAudioRoute_None
                                      error:&setCategoryError];
   if (setCategoryError == nil) {
-    NSString* outputAfter = [RTCAudioSession sharedInstance].currentRoute.outputs.firstObject.portType;
-    [self tvoxRouteLog:@"[TVoxRouteDebug] mediaStream selectAudioOutput fallback-none outputAfter=%@",
-          outputAfter];
     result(nil);
     return;
   }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -22,6 +22,7 @@
 
 #import <WebRTC/RTCLogging.h>
 #import <WebRTC/RTCCallbackLogger.h>
+#import <stdarg.h>
 
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
 #import <CoreGraphics/CoreGraphics.h>
@@ -115,6 +116,10 @@ void postEvent(FlutterEventSink _Nullable sink, id _Nullable event) {
   id _textures;
   BOOL _speakerOn;
   BOOL _speakerOnButPreferBluetooth;
+  BOOL _isRestoringRouteAfterCategoryChange;
+  BOOL _didRouteRecoveryForCurrentCall;
+  BOOL _audioSessionRecoveryPending;
+  BOOL _isRunningAudioSessionRecovery;
   AVAudioSessionPort _preferredInput;
   AudioManager* _audioManager;
 #if TARGET_OS_IPHONE
@@ -179,6 +184,10 @@ static FlutterWebRTCPlugin *sharedSingleton;
     _messenger = messenger;
     _speakerOn = NO;
     _speakerOnButPreferBluetooth = NO;
+    _isRestoringRouteAfterCategoryChange = NO;
+    _didRouteRecoveryForCurrentCall = NO;
+    _audioSessionRecoveryPending = NO;
+    _isRunningAudioSessionRecovery = NO;
     _eventChannel = eventChannel;
     _audioManager = AudioManager.sharedInstance;
 
@@ -248,6 +257,46 @@ static FlutterWebRTCPlugin *sharedSingleton;
   NSDictionary* interuptionDict = notification.userInfo;
   NSInteger routeChangeReason =
       [[interuptionDict valueForKey:AVAudioSessionRouteChangeReasonKey] integerValue];
+  NSString* currentOutputPortType = [self currentOutputPortType];
+  BOOL onBuiltInReceiver = [currentOutputPortType isEqualToString:AVAudioSessionPortBuiltInReceiver];
+  BOOL shouldRestoreSpeaker =
+      _speakerOn && onBuiltInReceiver;
+  BOOL shouldRestoreSpeakerOrBluetooth =
+      _speakerOnButPreferBluetooth && onBuiltInReceiver;
+  [self tvoxRouteLog:@"[TVoxRouteDebug] didSessionRouteChange reason=%ld output=%@ speakerOn=%d speakerPrefBt=%d restoreSpeaker=%d restoreSpeakerOrBt=%d",
+        (long)routeChangeReason,
+        currentOutputPortType,
+        _speakerOn,
+        _speakerOnButPreferBluetooth,
+        shouldRestoreSpeaker,
+        shouldRestoreSpeakerOrBluetooth];
+
+  if (routeChangeReason == AVAudioSessionRouteChangeReasonCategoryChange &&
+      !_isRestoringRouteAfterCategoryChange &&
+      !_didRouteRecoveryForCurrentCall &&
+      (shouldRestoreSpeaker || shouldRestoreSpeakerOrBluetooth)) {
+    [self tvoxRouteLog:@"[TVoxRouteDebug] restoring route after categoryChange"];
+    _isRestoringRouteAfterCategoryChange = YES;
+    if (_speakerOnButPreferBluetooth) {
+      [AudioUtils setSpeakerphoneOnButPreferBluetooth];
+    } else if (_speakerOn) {
+      [AudioUtils setSpeakerphoneOn:YES];
+    }
+    _isRestoringRouteAfterCategoryChange = NO;
+    _didRouteRecoveryForCurrentCall = YES;
+    currentOutputPortType = [self currentOutputPortType];
+    [self tvoxRouteLog:@"[TVoxRouteDebug] route restored output=%@", currentOutputPortType];
+  }
+
+  // Some iOS/CallKit transitions leave RTCAudioSession inactive while a call is alive,
+  // causing playout/recording init failures ("Session activation failed").
+  // Run bounded retries from WebRTC side to recover autonomously.
+  if ((routeChangeReason == AVAudioSessionRouteChangeReasonCategoryChange ||
+       routeChangeReason == AVAudioSessionRouteChangeReasonOverride) &&
+      self.peerConnections.count > 0) {
+    [self scheduleAudioSessionRecovery:@"routeChange"];
+  }
+
   if (self.eventSink &&
       (routeChangeReason == AVAudioSessionRouteChangeReasonNewDeviceAvailable ||
        routeChangeReason == AVAudioSessionRouteChangeReasonOldDeviceUnavailable ||
@@ -286,6 +335,21 @@ static FlutterWebRTCPlugin *sharedSingleton;
   }
 
   return RTCLoggingSeverityNone;
+}
+
+- (void)tvoxRouteLog:(NSString*)format, ... {
+  va_list args;
+  va_start(args, format);
+  NSString* message = [[NSString alloc] initWithFormat:format arguments:args];
+  va_end(args);
+
+  RTCLog(@"%@", message);
+  if (self.eventSink) {
+    postEvent(self.eventSink, @{
+      @"event" : @"onLogData",
+      @"data" : message
+    });
+  }
 }
 
 - (void)initialize:(NSArray*)networkIgnoreMask
@@ -383,6 +447,22 @@ static FlutterWebRTCPlugin *sharedSingleton;
     NSDictionary* argsMap = call.arguments;
     NSDictionary* configuration = argsMap[@"configuration"];
     NSDictionary* constraints = argsMap[@"constraints"];
+    [self tvoxRouteLog:@"[TVoxRouteDebug] createPeerConnection start output=%@ speakerOn=%d speakerPrefBt=%d",
+          [self currentOutputPortType],
+          _speakerOn,
+          _speakerOnButPreferBluetooth];
+    // New call lifecycle: start with neutral route memory.
+    // Prevent stale speaker preference from previous calls affecting fresh calls.
+    _speakerOn = NO;
+    _speakerOnButPreferBluetooth = NO;
+    _isRestoringRouteAfterCategoryChange = NO;
+    _didRouteRecoveryForCurrentCall = NO;
+    _audioSessionRecoveryPending = NO;
+    _isRunningAudioSessionRecovery = NO;
+    [self tvoxRouteLog:@"[TVoxRouteDebug] createPeerConnection reset output=%@ speakerOn=%d speakerPrefBt=%d",
+          [self currentOutputPortType],
+          _speakerOn,
+          _speakerOnButPreferBluetooth];
 
     RTCPeerConnection* peerConnection = [self.peerConnectionFactory
         peerConnectionWithConfiguration:[self RTCConfiguration:configuration]
@@ -443,6 +523,20 @@ static FlutterWebRTCPlugin *sharedSingleton;
   } else if ([@"selectAudioOutput" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     NSString* deviceId = argsMap[@"deviceId"];
+    NSString* normalized = [deviceId lowercaseString];
+    BOOL selectingSpeaker =
+        [normalized isEqualToString:@"speaker"] ||
+        [normalized isEqualToString:@"speakerphone"] ||
+        [normalized containsString:@"speaker"] ||
+        [normalized containsString:@"altoparlante"];
+    [self tvoxRouteLog:@"[TVoxRouteDebug] selectAudioOutput requested=%@ normalized=%@ selectingSpeaker=%d outputBefore=%@",
+          deviceId,
+          normalized,
+          selectingSpeaker,
+          [self currentOutputPortType]];
+    _speakerOn = selectingSpeaker;
+    _speakerOnButPreferBluetooth = NO;
+    _didRouteRecoveryForCurrentCall = NO;
     [self selectAudioOutput:deviceId result:result];
   } else if ([@"mediaStreamGetTracks" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
@@ -848,6 +942,19 @@ static FlutterWebRTCPlugin *sharedSingleton;
       }
       [dataChannels removeAllObjects];
     }
+    if (self.peerConnections.count == 0) {
+      _speakerOn = NO;
+      _speakerOnButPreferBluetooth = NO;
+      _isRestoringRouteAfterCategoryChange = NO;
+      _didRouteRecoveryForCurrentCall = NO;
+      _audioSessionRecoveryPending = NO;
+      _isRunningAudioSessionRecovery = NO;
+    }
+    [self tvoxRouteLog:@"[TVoxRouteDebug] peerConnection closed/disposed output=%@ speakerOn=%d speakerPrefBt=%d peers=%lu",
+          [self currentOutputPortType],
+          _speakerOn,
+          _speakerOnButPreferBluetooth,
+          (unsigned long)self.peerConnections.count];
     [self deactiveRtcAudioSession];
     result(nil);
   } else if ([@"createVideoRenderer" isEqualToString:call.method]) {
@@ -1127,6 +1234,12 @@ static FlutterWebRTCPlugin *sharedSingleton;
   else if ([@"ensureAudioSession" isEqualToString:call.method]) {
     [self ensureAudioSession];
     result(nil);
+  }
+  else if ([@"restartLocalAudio" isEqualToString:call.method]) {
+    NSDictionary* argsMap = call.arguments;
+    NSString* reason = argsMap[@"reason"] ?: @"manual";
+    [self ensureAudioSession];
+    [self restartAudioDeviceModule:reason result:result];
   }
   else if ([@"enableSpeakerphoneButPreferBluetooth" isEqualToString:call.method]) {
     _speakerOn = YES;
@@ -1727,17 +1840,237 @@ static FlutterWebRTCPlugin *sharedSingleton;
   return NO;
 }
 
+- (void)recoverAudioDeviceModuleIfNeeded:(NSString*)reason {
+#if TARGET_OS_IPHONE
+  if (self.peerConnections.count == 0 || self.peerConnectionFactory == nil) {
+    return;
+  }
+  RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
+  if (adm == nil) {
+    return;
+  }
+
+  BOOL needsPlayoutRecovery = !adm.isPlayoutInitialized || !adm.isPlaying;
+  BOOL needsRecordingRecovery = !adm.isRecordingInitialized || !adm.isRecording;
+  if (!needsPlayoutRecovery && !needsRecordingRecovery) {
+    return;
+  }
+
+  [self tvoxRouteLog:@"[TVoxRouteDebug] adm recovery requested reason=%@ playInit=%d playing=%d recInit=%d recording=%d",
+        reason,
+        adm.isPlayoutInitialized,
+        adm.isPlaying,
+        adm.isRecordingInitialized,
+        adm.isRecording];
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+    NSInteger initPlayoutResult = 0;
+    NSInteger startPlayoutResult = 0;
+    NSInteger initRecordingResult = 0;
+    NSInteger startRecordingResult = 0;
+
+    if (!adm.isPlayoutInitialized) {
+      initPlayoutResult = [adm initPlayout];
+    }
+    if (!adm.isPlaying) {
+      startPlayoutResult = [adm startPlayout];
+    }
+    if (!adm.isRecordingInitialized) {
+      initRecordingResult = [adm initRecording];
+    }
+    if (!adm.isRecording) {
+      startRecordingResult = [adm startRecording];
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self tvoxRouteLog:@"[TVoxRouteDebug] adm recovery completed reason=%@ initPlayout=%ld startPlayout=%ld initRecording=%ld startRecording=%ld playInit=%d playing=%d recInit=%d recording=%d",
+            reason,
+            (long)initPlayoutResult,
+            (long)startPlayoutResult,
+            (long)initRecordingResult,
+            (long)startRecordingResult,
+            adm.isPlayoutInitialized,
+            adm.isPlaying,
+            adm.isRecordingInitialized,
+            adm.isRecording];
+    });
+  });
+#endif
+}
+
+- (void)restartAudioDeviceModule:(NSString*)reason result:(FlutterResult)result {
+#if TARGET_OS_IPHONE
+  if (self.peerConnectionFactory == nil) {
+    result([FlutterError errorWithCode:@"restartLocalAudio failed"
+                               message:@"Error: peerConnectionFactory is nil"
+                               details:nil]);
+    return;
+  }
+
+  RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
+  if (adm == nil) {
+    result([FlutterError errorWithCode:@"restartLocalAudio failed"
+                               message:@"Error: audioDeviceModule is nil"
+                               details:nil]);
+    return;
+  }
+
+  [self tvoxRouteLog:@"[TVoxRouteDebug] restartLocalAudio requested reason=%@", reason];
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+    NSInteger stopPlayoutResult = [adm stopPlayout];
+    NSInteger stopRecordingResult = [adm stopRecording];
+    NSInteger initPlayoutResult = [adm initPlayout];
+    NSInteger startPlayoutResult = [adm startPlayout];
+    NSInteger initRecordingResult = [adm initRecording];
+    NSInteger startRecordingResult = [adm startRecording];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self tvoxRouteLog:@"[TVoxRouteDebug] restartLocalAudio completed reason=%@ stopPlayout=%ld stopRecording=%ld initPlayout=%ld startPlayout=%ld initRecording=%ld startRecording=%ld playInit=%d playing=%d recInit=%d recording=%d",
+            reason,
+            (long)stopPlayoutResult,
+            (long)stopRecordingResult,
+            (long)initPlayoutResult,
+            (long)startPlayoutResult,
+            (long)initRecordingResult,
+            (long)startRecordingResult,
+            adm.isPlayoutInitialized,
+            adm.isPlaying,
+            adm.isRecordingInitialized,
+            adm.isRecording];
+      result(nil);
+    });
+  });
+#else
+  result(nil);
+#endif
+}
+
 - (void)ensureAudioSession {
 #if TARGET_OS_IPHONE
-  [AudioUtils ensureAudioSessionWithRecording:[self hasLocalAudioTrack]];
+  BOOL hasLocalAudio = [self hasLocalAudioTrack];
+  NSUInteger peers = self.peerConnections.count;
+  BOOL shouldRecord = hasLocalAudio || peers > 0;
+  [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession before output=%@ hasLocalAudio=%d peers=%lu",
+        [self currentOutputPortType],
+        hasLocalAudio,
+        (unsigned long)peers];
+  [AudioUtils ensureAudioSessionWithRecording:shouldRecord];
+  RTCAudioSession* session = [RTCAudioSession sharedInstance];
+  if (shouldRecord && !session.isActive) {
+    NSError* error = nil;
+    [session lockForConfiguration];
+    BOOL activated = [session setActive:YES error:&error];
+    [session unlockForConfiguration];
+    if (!activated) {
+      [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession setActive failed: %@", error];
+      if (peers > 0 && !_isRunningAudioSessionRecovery) {
+        [self scheduleAudioSessionRecovery:@"ensureAudioSession.setActive.failed"];
+      }
+    } else {
+      [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession activated session"];
+    }
+  }
+  if (peers > 0 && session.isActive) {
+    [self recoverAudioDeviceModuleIfNeeded:@"ensureAudioSession"];
+  }
+  [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession after output=%@",
+        [self currentOutputPortType]];
 #endif
 }
 
 - (void)deactiveRtcAudioSession {
 #if TARGET_OS_IPHONE
   if (![self hasLocalAudioTrack] && self.peerConnections.count == 0) {
+    _speakerOn = NO;
+    _speakerOnButPreferBluetooth = NO;
+    _isRestoringRouteAfterCategoryChange = NO;
+    _didRouteRecoveryForCurrentCall = NO;
+    _audioSessionRecoveryPending = NO;
+    _isRunningAudioSessionRecovery = NO;
+    [self tvoxRouteLog:@"[TVoxRouteDebug] deactiveRtcAudioSession outputBefore=%@",
+          [self currentOutputPortType]];
     [AudioUtils deactiveRtcAudioSession];
+    [self tvoxRouteLog:@"[TVoxRouteDebug] deactiveRtcAudioSession outputAfter=%@",
+          [self currentOutputPortType]];
   }
+#endif
+}
+
+- (void)scheduleAudioSessionRecovery:(NSString*)reason {
+#if TARGET_OS_IPHONE
+  if (_audioSessionRecoveryPending) {
+    return;
+  }
+  _audioSessionRecoveryPending = YES;
+  [self tvoxRouteLog:@"[TVoxRouteDebug] scheduling audio session recovery reason=%@ peers=%lu",
+        reason,
+        (unsigned long)self.peerConnections.count];
+  [self runAudioSessionRecoveryAttempt:1 maxAttempts:4 reason:reason];
+#endif
+}
+
+- (void)runAudioSessionRecoveryAttempt:(NSInteger)attempt
+                           maxAttempts:(NSInteger)maxAttempts
+                                reason:(NSString*)reason {
+#if TARGET_OS_IPHONE
+  int64_t delayMs = (int64_t)(90 * attempt);
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, delayMs * NSEC_PER_MSEC),
+                 dispatch_get_main_queue(), ^{
+    if (self.peerConnections.count == 0) {
+      _audioSessionRecoveryPending = NO;
+      _isRunningAudioSessionRecovery = NO;
+      return;
+    }
+
+    RTCAudioSession* session = [RTCAudioSession sharedInstance];
+    if (!session.isActive) {
+      _isRunningAudioSessionRecovery = YES;
+      [self tvoxRouteLog:@"[TVoxRouteDebug] recovery attempt=%ld/%ld reason=%@ sessionActive=0",
+            (long)attempt,
+            (long)maxAttempts,
+            reason];
+      [self ensureAudioSession];
+      _isRunningAudioSessionRecovery = NO;
+
+      if (_speakerOnButPreferBluetooth) {
+        [AudioUtils setSpeakerphoneOnButPreferBluetooth];
+      } else if (_speakerOn) {
+        [AudioUtils setSpeakerphoneOn:YES];
+      }
+      session = [RTCAudioSession sharedInstance];
+    }
+
+    if (session.isActive) {
+      [self recoverAudioDeviceModuleIfNeeded:[NSString stringWithFormat:@"recovery.%@", reason ?: @"unknown"]];
+      _audioSessionRecoveryPending = NO;
+      [self tvoxRouteLog:@"[TVoxRouteDebug] recovery completed on attempt=%ld reason=%@",
+            (long)attempt,
+            reason];
+      return;
+    }
+
+    if (attempt >= maxAttempts) {
+      _audioSessionRecoveryPending = NO;
+      [self tvoxRouteLog:@"[TVoxRouteDebug] recovery exhausted after %ld attempts reason=%@",
+            (long)maxAttempts,
+            reason];
+      return;
+    }
+
+    [self runAudioSessionRecoveryAttempt:attempt + 1
+                             maxAttempts:maxAttempts
+                                  reason:reason];
+  });
+#endif
+}
+
+- (NSString*)currentOutputPortType {
+#if TARGET_OS_IPHONE
+  RTCAudioSession* session = [RTCAudioSession sharedInstance];
+  AVAudioSessionPortDescription* output = session.currentRoute.outputs.firstObject;
+  return output.portType ?: @"(none)";
+#else
+  return @"(unsupported)";
 #endif
 }
 

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -263,19 +263,11 @@ static FlutterWebRTCPlugin *sharedSingleton;
       _speakerOn && onBuiltInReceiver;
   BOOL shouldRestoreSpeakerOrBluetooth =
       _speakerOnButPreferBluetooth && onBuiltInReceiver;
-  [self tvoxRouteLog:@"[TVoxRouteDebug] didSessionRouteChange reason=%ld output=%@ speakerOn=%d speakerPrefBt=%d restoreSpeaker=%d restoreSpeakerOrBt=%d",
-        (long)routeChangeReason,
-        currentOutputPortType,
-        _speakerOn,
-        _speakerOnButPreferBluetooth,
-        shouldRestoreSpeaker,
-        shouldRestoreSpeakerOrBluetooth];
 
   if (routeChangeReason == AVAudioSessionRouteChangeReasonCategoryChange &&
       !_isRestoringRouteAfterCategoryChange &&
       !_didRouteRecoveryForCurrentCall &&
       (shouldRestoreSpeaker || shouldRestoreSpeakerOrBluetooth)) {
-    [self tvoxRouteLog:@"[TVoxRouteDebug] restoring route after categoryChange"];
     _isRestoringRouteAfterCategoryChange = YES;
     if (_speakerOnButPreferBluetooth) {
       [AudioUtils setSpeakerphoneOnButPreferBluetooth];
@@ -284,8 +276,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
     }
     _isRestoringRouteAfterCategoryChange = NO;
     _didRouteRecoveryForCurrentCall = YES;
-    currentOutputPortType = [self currentOutputPortType];
-    [self tvoxRouteLog:@"[TVoxRouteDebug] route restored output=%@", currentOutputPortType];
   }
 
   // Some iOS/CallKit transitions leave RTCAudioSession inactive while a call is alive,
@@ -335,21 +325,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
   }
 
   return RTCLoggingSeverityNone;
-}
-
-- (void)tvoxRouteLog:(NSString*)format, ... {
-  va_list args;
-  va_start(args, format);
-  NSString* message = [[NSString alloc] initWithFormat:format arguments:args];
-  va_end(args);
-
-  RTCLog(@"%@", message);
-  if (self.eventSink) {
-    postEvent(self.eventSink, @{
-      @"event" : @"onLogData",
-      @"data" : message
-    });
-  }
 }
 
 - (void)initialize:(NSArray*)networkIgnoreMask
@@ -447,10 +422,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
     NSDictionary* argsMap = call.arguments;
     NSDictionary* configuration = argsMap[@"configuration"];
     NSDictionary* constraints = argsMap[@"constraints"];
-    [self tvoxRouteLog:@"[TVoxRouteDebug] createPeerConnection start output=%@ speakerOn=%d speakerPrefBt=%d",
-          [self currentOutputPortType],
-          _speakerOn,
-          _speakerOnButPreferBluetooth];
     // New call lifecycle: start with neutral route memory.
     // Prevent stale speaker preference from previous calls affecting fresh calls.
     _speakerOn = NO;
@@ -459,10 +430,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
     _didRouteRecoveryForCurrentCall = NO;
     _audioSessionRecoveryPending = NO;
     _isRunningAudioSessionRecovery = NO;
-    [self tvoxRouteLog:@"[TVoxRouteDebug] createPeerConnection reset output=%@ speakerOn=%d speakerPrefBt=%d",
-          [self currentOutputPortType],
-          _speakerOn,
-          _speakerOnButPreferBluetooth];
 
     RTCPeerConnection* peerConnection = [self.peerConnectionFactory
         peerConnectionWithConfiguration:[self RTCConfiguration:configuration]
@@ -529,11 +496,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
         [normalized isEqualToString:@"speakerphone"] ||
         [normalized containsString:@"speaker"] ||
         [normalized containsString:@"altoparlante"];
-    [self tvoxRouteLog:@"[TVoxRouteDebug] selectAudioOutput requested=%@ normalized=%@ selectingSpeaker=%d outputBefore=%@",
-          deviceId,
-          normalized,
-          selectingSpeaker,
-          [self currentOutputPortType]];
     _speakerOn = selectingSpeaker;
     _speakerOnButPreferBluetooth = NO;
     _didRouteRecoveryForCurrentCall = NO;
@@ -950,11 +912,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
       _audioSessionRecoveryPending = NO;
       _isRunningAudioSessionRecovery = NO;
     }
-    [self tvoxRouteLog:@"[TVoxRouteDebug] peerConnection closed/disposed output=%@ speakerOn=%d speakerPrefBt=%d peers=%lu",
-          [self currentOutputPortType],
-          _speakerOn,
-          _speakerOnButPreferBluetooth,
-          (unsigned long)self.peerConnections.count];
     [self deactiveRtcAudioSession];
     result(nil);
   } else if ([@"createVideoRenderer" isEqualToString:call.method]) {
@@ -1856,12 +1813,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
     return;
   }
 
-  [self tvoxRouteLog:@"[TVoxRouteDebug] adm recovery requested reason=%@ playInit=%d playing=%d recInit=%d recording=%d",
-        reason,
-        adm.isPlayoutInitialized,
-        adm.isPlaying,
-        adm.isRecordingInitialized,
-        adm.isRecording];
 
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
     NSInteger initPlayoutResult = 0;
@@ -1883,16 +1834,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
     }
 
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self tvoxRouteLog:@"[TVoxRouteDebug] adm recovery completed reason=%@ initPlayout=%ld startPlayout=%ld initRecording=%ld startRecording=%ld playInit=%d playing=%d recInit=%d recording=%d",
-            reason,
-            (long)initPlayoutResult,
-            (long)startPlayoutResult,
-            (long)initRecordingResult,
-            (long)startRecordingResult,
-            adm.isPlayoutInitialized,
-            adm.isPlaying,
-            adm.isRecordingInitialized,
-            adm.isRecording];
     });
   });
 #endif
@@ -1900,6 +1841,7 @@ static FlutterWebRTCPlugin *sharedSingleton;
 
 - (void)restartAudioDeviceModule:(NSString*)reason result:(FlutterResult)result {
 #if TARGET_OS_IPHONE
+  (void)reason;
   if (self.peerConnectionFactory == nil) {
     result([FlutterError errorWithCode:@"restartLocalAudio failed"
                                message:@"Error: peerConnectionFactory is nil"
@@ -1915,28 +1857,15 @@ static FlutterWebRTCPlugin *sharedSingleton;
     return;
   }
 
-  [self tvoxRouteLog:@"[TVoxRouteDebug] restartLocalAudio requested reason=%@", reason];
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
-    NSInteger stopPlayoutResult = [adm stopPlayout];
-    NSInteger stopRecordingResult = [adm stopRecording];
-    NSInteger initPlayoutResult = [adm initPlayout];
-    NSInteger startPlayoutResult = [adm startPlayout];
-    NSInteger initRecordingResult = [adm initRecording];
-    NSInteger startRecordingResult = [adm startRecording];
+    [adm stopPlayout];
+    [adm stopRecording];
+    [adm initPlayout];
+    [adm startPlayout];
+    [adm initRecording];
+    [adm startRecording];
 
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self tvoxRouteLog:@"[TVoxRouteDebug] restartLocalAudio completed reason=%@ stopPlayout=%ld stopRecording=%ld initPlayout=%ld startPlayout=%ld initRecording=%ld startRecording=%ld playInit=%d playing=%d recInit=%d recording=%d",
-            reason,
-            (long)stopPlayoutResult,
-            (long)stopRecordingResult,
-            (long)initPlayoutResult,
-            (long)startPlayoutResult,
-            (long)initRecordingResult,
-            (long)startRecordingResult,
-            adm.isPlayoutInitialized,
-            adm.isPlaying,
-            adm.isRecordingInitialized,
-            adm.isRecording];
       result(nil);
     });
   });
@@ -1950,10 +1879,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
   BOOL hasLocalAudio = [self hasLocalAudioTrack];
   NSUInteger peers = self.peerConnections.count;
   BOOL shouldRecord = hasLocalAudio || peers > 0;
-  [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession before output=%@ hasLocalAudio=%d peers=%lu",
-        [self currentOutputPortType],
-        hasLocalAudio,
-        (unsigned long)peers];
   [AudioUtils ensureAudioSessionWithRecording:shouldRecord];
   RTCAudioSession* session = [RTCAudioSession sharedInstance];
   if (shouldRecord && !session.isActive) {
@@ -1962,19 +1887,14 @@ static FlutterWebRTCPlugin *sharedSingleton;
     BOOL activated = [session setActive:YES error:&error];
     [session unlockForConfiguration];
     if (!activated) {
-      [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession setActive failed: %@", error];
       if (peers > 0 && !_isRunningAudioSessionRecovery) {
         [self scheduleAudioSessionRecovery:@"ensureAudioSession.setActive.failed"];
       }
-    } else {
-      [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession activated session"];
     }
   }
   if (peers > 0 && session.isActive) {
     [self recoverAudioDeviceModuleIfNeeded:@"ensureAudioSession"];
   }
-  [self tvoxRouteLog:@"[TVoxRouteDebug] ensureAudioSession after output=%@",
-        [self currentOutputPortType]];
 #endif
 }
 
@@ -1987,11 +1907,7 @@ static FlutterWebRTCPlugin *sharedSingleton;
     _didRouteRecoveryForCurrentCall = NO;
     _audioSessionRecoveryPending = NO;
     _isRunningAudioSessionRecovery = NO;
-    [self tvoxRouteLog:@"[TVoxRouteDebug] deactiveRtcAudioSession outputBefore=%@",
-          [self currentOutputPortType]];
     [AudioUtils deactiveRtcAudioSession];
-    [self tvoxRouteLog:@"[TVoxRouteDebug] deactiveRtcAudioSession outputAfter=%@",
-          [self currentOutputPortType]];
   }
 #endif
 }
@@ -2002,9 +1918,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
     return;
   }
   _audioSessionRecoveryPending = YES;
-  [self tvoxRouteLog:@"[TVoxRouteDebug] scheduling audio session recovery reason=%@ peers=%lu",
-        reason,
-        (unsigned long)self.peerConnections.count];
   [self runAudioSessionRecoveryAttempt:1 maxAttempts:4 reason:reason];
 #endif
 }
@@ -2025,10 +1938,6 @@ static FlutterWebRTCPlugin *sharedSingleton;
     RTCAudioSession* session = [RTCAudioSession sharedInstance];
     if (!session.isActive) {
       _isRunningAudioSessionRecovery = YES;
-      [self tvoxRouteLog:@"[TVoxRouteDebug] recovery attempt=%ld/%ld reason=%@ sessionActive=0",
-            (long)attempt,
-            (long)maxAttempts,
-            reason];
       [self ensureAudioSession];
       _isRunningAudioSessionRecovery = NO;
 
@@ -2043,17 +1952,11 @@ static FlutterWebRTCPlugin *sharedSingleton;
     if (session.isActive) {
       [self recoverAudioDeviceModuleIfNeeded:[NSString stringWithFormat:@"recovery.%@", reason ?: @"unknown"]];
       _audioSessionRecoveryPending = NO;
-      [self tvoxRouteLog:@"[TVoxRouteDebug] recovery completed on attempt=%ld reason=%@",
-            (long)attempt,
-            reason];
       return;
     }
 
     if (attempt >= maxAttempts) {
       _audioSessionRecoveryPending = NO;
-      [self tvoxRouteLog:@"[TVoxRouteDebug] recovery exhausted after %ld attempts reason=%@",
-            (long)maxAttempts,
-            reason];
       return;
     }
 


### PR DESCRIPTION
## Summary
This PR fixes iOS audio device/routing instability in our WebRTC call flow (especially around CallKit answer/background transitions), where calls could connect but still have no audio or route to the wrong output device.

## Problem
On iOS we were seeing intermittent audio failures such as:
- `RTCAudioSession` activation failures (`Session activation failed`)
- playout initialization failures (`InitPlayout` / `output: -1`)
- route/category transitions unexpectedly switching output (Speaker/Receiver)
- video calls sometimes ending up on earpiece instead of speaker

## Root Cause
The issue was a combination of:
1. Audio session transitions (CallKit ↔ WebRTC) leaving `RTCAudioSession` temporarily inactive.
2. WebRTC AudioDeviceModule (ADM) not always recovering playout/recording after those transitions.
3. Route/category changes reverting output selection during active calls.

## What We Changed
### 1) iOS audio session recovery
- Added bounded recovery attempts when the audio session fails to become active.
- Triggered recovery on relevant iOS route/category changes while a call is alive.

### 2) WebRTC ADM recovery
- Added explicit ADM recovery to re-initialize/start playout and recording when needed.
- This prevents “connected call but no audio” states after session interruptions.

### 3) Explicit local audio restart path
- Added a native restart entrypoint (`restartLocalAudio`) to allow controlled audio pipeline restart from upper layers.

### 4) Safer output routing behavior on iOS
- Hardened Speaker/Receiver handling during route/category transitions.
- Ensures video-call routing expectations (speaker-first behavior) remain stable.

## Expected Impact
- Fewer iOS cases of “call connected but no audio”.
- More stable audio output routing across CallKit/category/route transitions.
- Improved reliability for both inbound and outbound WebRTC calls on iOS.

## Scope
- No intended behavioral changes for Android.
