### PR TITLE
fix(android): guard muxer writes against codec-config and invalid sample buffers

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/record/VideoFileRenderer.java
@@ -403,13 +403,23 @@ class VideoFileRenderer implements VideoSink, SamplesReadyCallback {
                         Log.e(TAG, "encoderOutputBuffer " + encoderStatus + " was null");
                         break;
                     }
+                    if ((bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                        bufferInfo.size = 0;
+                    }
+                    if (bufferInfo.size <= 0 || bufferInfo.offset < 0) {
+                        encoder.releaseOutputBuffer(encoderStatus, false);
+                        if ((bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                            break;
+                        }
+                        continue;
+                    }
                     // It's usually necessary to adjust the ByteBuffer values to match BufferInfo.
                     encodedData.position(bufferInfo.offset);
                     encodedData.limit(bufferInfo.offset + bufferInfo.size);
                     if (videoFrameStart == 0 && bufferInfo.presentationTimeUs != 0) {
                         videoFrameStart = bufferInfo.presentationTimeUs;
                     }
-                    bufferInfo.presentationTimeUs -= videoFrameStart;
+                    bufferInfo.presentationTimeUs = Math.max(0, bufferInfo.presentationTimeUs - videoFrameStart);
                     if (muxerStarted)
                         mediaMuxer.writeSampleData(trackIndex, encodedData, bufferInfo);
                     isRunning = isRunning && (bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) == 0;
@@ -465,6 +475,16 @@ class VideoFileRenderer implements VideoSink, SamplesReadyCallback {
                     if (encodedData == null) {
                         Log.e(TAG, "encoderOutputBuffer " + encoderStatus + " was null");
                         break;
+                    }
+                    if ((audioBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                        audioBufferInfo.size = 0;
+                    }
+                    if (audioBufferInfo.size <= 0 || audioBufferInfo.offset < 0) {
+                        audioEncoder.releaseOutputBuffer(encoderStatus, false);
+                        if ((audioBufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                            break;
+                        }
+                        continue;
                     }
 
                     // It's usually necessary to adjust the ByteBuffer values to match BufferInfo.


### PR DESCRIPTION
## Summary

This change adds defensive checks before writing encoded samples into
`MediaMuxer` during Android recording shutdown/drain.

## What changed

- Ignore `BUFFER_FLAG_CODEC_CONFIG` buffers
- Skip samples with invalid `offset` / `size`
- Clamp video presentation timestamps to non-negative values

## Why

Without these guards, some recordings can fail during stop/drain with errors
similar to:

- `bufferInfo must specify a valid buffer offset, size and presentation time`

These buffers should not be written as regular media samples.

## Expected result

- Cleaner stop path for Android recordings
- Fewer muxer exceptions at the end of recording
- More reliable mp4 finalization
