### PR TITLE
Using delete[] instead of delete

### DIFF
--- a/common/cpp/include/flutter_video_renderer.h
+++ b/common/cpp/include/flutter_video_renderer.h
@@ -55,7 +55,7 @@ class FlutterVideoRenderer
   scoped_refptr<RTCVideoFrame> frame_;
   std::unique_ptr<flutter::TextureVariant> texture_;
   std::shared_ptr<FlutterDesktopPixelBuffer> pixel_buffer_;
-  mutable std::shared_ptr<uint8_t> rgb_buffer_;
+  mutable std::shared_ptr<uint8_t[]> rgb_buffer_;
   mutable std::mutex mutex_;
   RTCVideoFrame::VideoRotation rotation_ = RTCVideoFrame::kVideoRotation_0;
 };


### PR DESCRIPTION
std::shared_ptr<uint8_t> uses scalar delete internally. Calling .reset() with a pointer from new[] means the array is freed with delete instead of delete[] — exactly what ASan reports: operator new [] vs       
  operator delete.