### PR TITLE
Fix Android screen capture after orientation changes

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
@@ -18,9 +18,9 @@ import android.hardware.display.DisplayManager;
 import android.util.DisplayMetrics;
 import android.hardware.display.VirtualDisplay;
 import android.media.projection.MediaProjectionManager;
-import android.os.Looper;
-import android.os.Handler;
-import android.os.Build;
+//import android.os.Looper;
+//import android.os.Handler;
+//import android.os.Build;
 import android.view.Display;
 
 /**
@@ -122,6 +122,8 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
             this.height = width;
             this.width = height;
         }
+        this.oldWidth = this.width;
+        this.oldHeight = this.height;
 
         mediaProjection = mediaProjectionManager.getMediaProjection(
                 Activity.RESULT_OK, mediaProjectionPermissionResultData);
@@ -175,40 +177,26 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
             final int width, final int height, final int ignoredFramerate) {
         checkNotDisposed();
         if (this.oldWidth != width || this.oldHeight != height) {
+            this.width = width;
+            this.height = height;
             this.oldWidth = width;
             this.oldHeight = height;
 
-            if (oldHeight > oldWidth) {
-                ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
-                    @Override
-                    public void run() {
-                        if (virtualDisplay != null && surfaceTextureHelper != null) {
-                            virtualDisplay.setSurface(new Surface(surfaceTextureHelper.getSurfaceTexture()));
-                            surfaceTextureHelper.setTextureSize(oldWidth, oldHeight);
-                            virtualDisplay.resize(oldWidth, oldHeight, VIRTUAL_DISPLAY_DPI);
-                        }
+            ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
+                @Override
+                public void run() {
+                    if (surfaceTextureHelper == null || mediaProjection == null) {
+                        return;
                     }
-                });
-            }
 
-            if (oldWidth > oldHeight) {
-                surfaceTextureHelper.setTextureSize(oldWidth, oldHeight);
-                virtualDisplay.setSurface(new Surface(surfaceTextureHelper.getSurfaceTexture()));
-                final Handler handler = new Handler(Looper.getMainLooper());
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
-                            @Override
-                            public void run() {
-                                if (virtualDisplay != null && surfaceTextureHelper != null) {
-                                    virtualDisplay.resize(oldWidth, oldHeight, VIRTUAL_DISPLAY_DPI);
-                                }
-                            }
-                        });
+                    if (virtualDisplay != null) {
+                        virtualDisplay.release();
+                        virtualDisplay = null;
                     }
-                }, 700);
-            }
+
+                    createVirtualDisplay();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This fixes Android screen capture frames after device orientation changes.

Problem:
When an Android device is used as screen-capture host and rotates from portrait to landscape or back, the remote viewer can receive frames with black areas, wrong offset, or squashed content. The existing implementation calls `VirtualDisplay.resize(...)`, but in some devices this does not fully realign the capture surface/buffer.

Fix:
When the capture format changes, release the existing `VirtualDisplay` and recreate it using the already authorized `MediaProjection`. This avoids asking for screen-capture permission again and produces correctly sized frames after rotation.

Also initialize `oldWidth` and `oldHeight` when capture starts, so the first frame does not trigger an unnecessary recreate.

Tested:
- Android tablet Samsung SM-T510 as screen-capture host
- iPhone viewer
- Portrait -> landscape -> portrait rotation during active WebRTC session
- No additional Android screen-capture prompt shown
<img width="585" height="1266" alt="before_horizontal" src="https://github.com/user-attachments/assets/a0088ab8-e380-4832-b789-59261bcbad4e" />
<img width="585" height="1266" alt="before_vertical_after_horizontal" src="https://github.com/user-attachments/assets/3723c9ee-a697-40d3-8bba-a715044bb356" />
