### PR TITLE
Fix handling of `KeyDerivationAlgorithm` option

### DIFF
--- a/common/cpp/include/flutter_frame_cryptor.h
+++ b/common/cpp/include/flutter_frame_cryptor.h
@@ -8,6 +8,10 @@
 
 namespace flutter_webrtc_plugin {
 
+KeyDerivationAlgorithm KeyDerivationAlgorithmFromInt(int algorithm);
+
+libwebrtc::FrameCryptorAlgorithm AlgorithmFromInt(int algorithm);
+
 class FlutterFrameCryptorObserver : public libwebrtc::RTCFrameCryptorObserver {
  public:
   FlutterFrameCryptorObserver(BinaryMessenger* messenger, TaskRunner* task_runner, const std::string& channelName)

--- a/common/cpp/src/flutter_data_packet_cryptor.cc
+++ b/common/cpp/src/flutter_data_packet_cryptor.cc
@@ -1,6 +1,7 @@
 #include "flutter_data_packet_cryptor.h"
 
 #include "base/scoped_ref_ptr.h"
+#include "flutter_frame_cryptor.h"
 
 namespace flutter_webrtc_plugin {
 
@@ -31,16 +32,6 @@ bool FlutterDataPacketCryptor::HandleDataPacketCryptorMethodCall(
   return false;
 }
 
-libwebrtc::FrameCryptorAlgorithm KeyDerivationAlgorithmFromInt(int algorithm) {
-  switch (algorithm) {
-    case 0:
-      return libwebrtc::FrameCryptorAlgorithm::kAesGcm;
-    case 1:
-      return libwebrtc::FrameCryptorAlgorithm::kAesCbc;
-    default:
-      return libwebrtc::FrameCryptorAlgorithm::kAesGcm;
-  }
-}
 
 void FlutterDataPacketCryptor::CreateDataPacketCryptor(
     const EncodableMap& constraints,
@@ -67,7 +58,7 @@ void FlutterDataPacketCryptor::CreateDataPacketCryptor(
   }
   std::string uuid = base_->GenerateUUID();
   data_packet_cryptors_[uuid] = libwebrtc::RTCDataPacketCryptor::Create(
-      keyProvider, KeyDerivationAlgorithmFromInt(algorithm));
+      keyProvider, AlgorithmFromInt(algorithm));
   EncodableMap params;
   params[EncodableValue("dataCryptorId")] = uuid;
   result->Success(EncodableValue(params));

--- a/common/cpp/src/flutter_frame_cryptor.cc
+++ b/common/cpp/src/flutter_frame_cryptor.cc
@@ -4,6 +4,17 @@
 
 namespace flutter_webrtc_plugin {
 
+libwebrtc::KeyDerivationAlgorithm KeyDerivationAlgorithmFromInt(int algorithm) {
+  switch (algorithm) {
+    case 0:
+      return libwebrtc::KeyDerivationAlgorithm::kPBKDF2;
+    case 1:
+      return libwebrtc::KeyDerivationAlgorithm::kHKDF;
+    default:
+      return libwebrtc::KeyDerivationAlgorithm::kPBKDF2;
+  }
+}
+
 libwebrtc::FrameCryptorAlgorithm AlgorithmFromInt(int algorithm) {
   switch (algorithm) {
     case 0:
@@ -354,6 +365,9 @@ void FlutterFrameCryptor::FrameCryptorFactoryCreateKeyProvider(
 
   auto keyRingSize = findInt(keyProviderOptions, "keyRingSize");
   options.key_ring_size = keyRingSize;
+
+  auto kdf = findInt(keyProviderOptions, "keyDerivationAlgorithm");
+  options.key_derivation_algorithm = KeyDerivationAlgorithmFromInt(kdf);
 
   auto discardFrameWhenCryptorNotReady =
       findBoolean(keyProviderOptions, "discardFrameWhenCryptorNotReady");


### PR DESCRIPTION
Currently on the flutter side, you can set a Key Derivation Algorithm, but the value is not actually passed to libwebrtc. This correctly parses the option.


Also tweaking the function `KeyDerivationAlgorithmFromInt` to properly return `libwebrtc::KeyDerivationAlgorithm` as opposed to the currently used `libwebrtc::FrameCryptorAlgorithm`