### PR TITLE
Event channel cleanup

### DIFF
--- a/common/cpp/include/flutter_peerconnection.h
+++ b/common/cpp/include/flutter_peerconnection.h
@@ -14,6 +14,7 @@ class FlutterPeerConnectionObserver : public RTCPeerConnectionObserver {
                                 TaskRunner* task_runner,
                                 const std::string& channel_name,
                                 std::string& peerConnectionId);
+  ~FlutterPeerConnectionObserver() override;
 
   virtual void OnSignalingState(RTCSignalingState state) override;
   virtual void OnPeerConnectionState(RTCPeerConnectionState state) override;

--- a/common/cpp/src/flutter_common.cc
+++ b/common/cpp/src/flutter_common.cc
@@ -101,7 +101,14 @@ class EventChannelProxyImpl : public EventChannelProxy {
      channel_->SetStreamHandler(std::move(handler));
    }
  
-   virtual ~EventChannelProxyImpl() {}
+   virtual ~EventChannelProxyImpl() {
+     if (channel_) {
+       channel_->SetStreamHandler(nullptr);
+     }
+     sink_.reset();
+     event_queue_.clear();
+     on_listen_called_ = false;
+   }
  
    void Success(const EncodableValue& event, bool cache_event = true) override {
      if (on_listen_called_) {

--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -1186,6 +1186,11 @@ FlutterPeerConnectionObserver::FlutterPeerConnectionObserver(
   peerconnection->RegisterRTCPeerConnectionObserver(this);
 }
 
+FlutterPeerConnectionObserver::~FlutterPeerConnectionObserver() {
+  if (peerconnection_) {
+    peerconnection_->DeRegisterRTCPeerConnectionObserver();
+  }
+}
 
 void FlutterPeerConnectionObserver::OnSignalingState(RTCSignalingState state) {
   EncodableMap params;


### PR DESCRIPTION
### Summary
- Unregister C++ event channel stream handlers during teardown.
- Deregister the peer connection observer before destroying it.

### Notes
This prevents stale native callbacks from targeting destroyed event channel or observer objects during repeated peer connection cleanup.