### PR TITLE
Fix android screen capture rotation

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
@@ -18,9 +18,6 @@ import android.hardware.display.DisplayManager;
 import android.util.DisplayMetrics;
 import android.hardware.display.VirtualDisplay;
 import android.media.projection.MediaProjectionManager;
-//import android.os.Looper;
-//import android.os.Handler;
-//import android.os.Build;
 import android.view.Display;
 
 /**
@@ -39,6 +36,7 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
     private int oldWidth;
     private int oldHeight;
     private VirtualDisplay virtualDisplay;
+    private Surface virtualDisplaySurface;
     private SurfaceTextureHelper surfaceTextureHelper;
     private CapturerObserver capturerObserver;
     private long numCapturedFrames = 0;
@@ -148,6 +146,7 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
                     virtualDisplay.release();
                     virtualDisplay = null;
                 }
+                releaseVirtualDisplaySurface();
                 if (mediaProjection != null) {
                     // Unregister the callback before stopping, otherwise the callback recursively
                     // calls this method.
@@ -190,22 +189,45 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
                     }
 
                     if (virtualDisplay != null) {
-                        virtualDisplay.release();
-                        virtualDisplay = null;
+                        resizeVirtualDisplay();
+                    } else {
+                        createVirtualDisplay();
                     }
-
-                    createVirtualDisplay();
                 }
             });
         }
     }
 
     private void createVirtualDisplay() {
+        updateSurfaceTextureSize();
+        releaseVirtualDisplaySurface();
+        virtualDisplaySurface = new Surface(surfaceTextureHelper.getSurfaceTexture());
+        virtualDisplay = mediaProjection.createVirtualDisplay("WebRTC_ScreenCapture", width, height,
+                VIRTUAL_DISPLAY_DPI, DISPLAY_FLAGS, virtualDisplaySurface,
+                null /* callback */, null /* callback handler */);
+    }
+
+    private void resizeVirtualDisplay() {
+        updateSurfaceTextureSize();
+        virtualDisplay.resize(width, height, VIRTUAL_DISPLAY_DPI);
+        final Surface oldSurface = virtualDisplaySurface;
+        virtualDisplaySurface = new Surface(surfaceTextureHelper.getSurfaceTexture());
+        virtualDisplay.setSurface(virtualDisplaySurface);
+        if (oldSurface != null) {
+            oldSurface.release();
+        }
+    }
+
+    private void updateSurfaceTextureSize() {
         surfaceTextureHelper.setTextureSize(width, height);
         surfaceTextureHelper.getSurfaceTexture().setDefaultBufferSize(width, height);
-        virtualDisplay = mediaProjection.createVirtualDisplay("WebRTC_ScreenCapture", width, height,
-                VIRTUAL_DISPLAY_DPI, DISPLAY_FLAGS, new Surface(surfaceTextureHelper.getSurfaceTexture()),
-                null /* callback */, null /* callback handler */);
+    }
+
+    private void releaseVirtualDisplaySurface() {
+        if (virtualDisplaySurface != null) {
+            virtualDisplaySurface.release();
+            virtualDisplaySurface = null;
+        }
     }
 
     @Override

--- a/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/OrientationAwareScreenCapturer.java
@@ -18,9 +18,9 @@ import android.hardware.display.DisplayManager;
 import android.util.DisplayMetrics;
 import android.hardware.display.VirtualDisplay;
 import android.media.projection.MediaProjectionManager;
-import android.os.Looper;
-import android.os.Handler;
-import android.os.Build;
+//import android.os.Looper;
+//import android.os.Handler;
+//import android.os.Build;
 import android.view.Display;
 
 /**
@@ -122,6 +122,8 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
             this.height = width;
             this.width = height;
         }
+        this.oldWidth = this.width;
+        this.oldHeight = this.height;
 
         mediaProjection = mediaProjectionManager.getMediaProjection(
                 Activity.RESULT_OK, mediaProjectionPermissionResultData);
@@ -175,40 +177,26 @@ public class OrientationAwareScreenCapturer implements VideoCapturer, VideoSink 
             final int width, final int height, final int ignoredFramerate) {
         checkNotDisposed();
         if (this.oldWidth != width || this.oldHeight != height) {
+            this.width = width;
+            this.height = height;
             this.oldWidth = width;
             this.oldHeight = height;
 
-            if (oldHeight > oldWidth) {
-                ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
-                    @Override
-                    public void run() {
-                        if (virtualDisplay != null && surfaceTextureHelper != null) {
-                            virtualDisplay.setSurface(new Surface(surfaceTextureHelper.getSurfaceTexture()));
-                            surfaceTextureHelper.setTextureSize(oldWidth, oldHeight);
-                            virtualDisplay.resize(oldWidth, oldHeight, VIRTUAL_DISPLAY_DPI);
-                        }
+            ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
+                @Override
+                public void run() {
+                    if (surfaceTextureHelper == null || mediaProjection == null) {
+                        return;
                     }
-                });
-            }
 
-            if (oldWidth > oldHeight) {
-                surfaceTextureHelper.setTextureSize(oldWidth, oldHeight);
-                virtualDisplay.setSurface(new Surface(surfaceTextureHelper.getSurfaceTexture()));
-                final Handler handler = new Handler(Looper.getMainLooper());
-                handler.postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        ThreadUtils.invokeAtFrontUninterruptibly(surfaceTextureHelper.getHandler(), new Runnable() {
-                            @Override
-                            public void run() {
-                                if (virtualDisplay != null && surfaceTextureHelper != null) {
-                                    virtualDisplay.resize(oldWidth, oldHeight, VIRTUAL_DISPLAY_DPI);
-                                }
-                            }
-                        });
+                    if (virtualDisplay != null) {
+                        virtualDisplay.release();
+                        virtualDisplay = null;
                     }
-                }, 700);
-            }
+
+                    createVirtualDisplay();
+                }
+            });
         }
     }
 

--- a/android/src/main/java/org/webrtc/video/CustomVideoDecoderFactory.java
+++ b/android/src/main/java/org/webrtc/video/CustomVideoDecoderFactory.java
@@ -10,7 +10,9 @@ import org.webrtc.VideoDecoderFactory;
 import org.webrtc.WrappedVideoDecoderFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class CustomVideoDecoderFactory implements VideoDecoderFactory {
     private SoftwareVideoDecoderFactory softwareVideoDecoderFactory = new SoftwareVideoDecoderFactory();
@@ -47,9 +49,43 @@ public class CustomVideoDecoderFactory implements VideoDecoderFactory {
 
     @Override
     public VideoCodecInfo[] getSupportedCodecs() {
+        VideoCodecInfo[] codecs;
         if(forceSWCodec && forceSWCodecs.isEmpty()) {
-            return softwareVideoDecoderFactory.getSupportedCodecs();
+            codecs = softwareVideoDecoderFactory.getSupportedCodecs();
+        } else {
+            codecs = wrappedVideoDecoderFactory.getSupportedCodecs();
         }
-        return wrappedVideoDecoderFactory.getSupportedCodecs();
+
+        return withHigherH264Level(codecs);
+    }
+
+    private VideoCodecInfo[] withHigherH264Level(VideoCodecInfo[] codecs) {
+        VideoCodecInfo[] adjustedCodecs = new VideoCodecInfo[codecs.length];
+        for (int i = 0; i < codecs.length; i++) {
+            VideoCodecInfo codec = codecs[i];
+            if (!"H264".equalsIgnoreCase(codec.name)) {
+                adjustedCodecs[i] = codec;
+                continue;
+            }
+
+            String profileLevelId = codec.params.get("profile-level-id");
+            if (profileLevelId == null || profileLevelId.length() != 6) {
+                adjustedCodecs[i] = codec;
+                continue;
+            }
+
+            String profile = profileLevelId.substring(0, 4);
+            String level = profileLevelId.substring(4);
+            if (Integer.parseInt(level, 16) >= 0x29) {
+                adjustedCodecs[i] = codec;
+                continue;
+            }
+
+            Map<String, String> params = new HashMap<>(codec.params);
+            params.put("profile-level-id", profile + "29");
+            adjustedCodecs[i] = new VideoCodecInfo(codec.name, params, codec.scalabilityModes);
+        }
+
+        return adjustedCodecs;
     }
 }


### PR DESCRIPTION
- Resize the existing VirtualDisplay instead of releasing/recreating it on orientation changes.
- Advertise H264 decoder support with at least level 4.1 (profile-level-id ...29) to allow higher-resolution iOS screen streams on Android.