### PR TITLE
chore: Refactoring the CMake binary download process for Win/Linux.

### DIFF
--- a/elinux/CMakeLists.txt
+++ b/elinux/CMakeLists.txt
@@ -51,12 +51,12 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE 
   flutter
   flutter_wrapper_plugin
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/${FLUTTER_TARGET_PLATFORM}/libwebrtc.so"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/libwebrtc.so"
 )
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(flutter_webrtc_bundled_libraries
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/${FLUTTER_TARGET_PLATFORM}/libwebrtc.so"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/libwebrtc.so"
   PARENT_SCOPE
 )
 

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -57,12 +57,12 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE 
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/${FLUTTER_TARGET_PLATFORM}/libwebrtc.so"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/libwebrtc.so"
 )
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(flutter_webrtc_bundled_libraries
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/${FLUTTER_TARGET_PLATFORM}/libwebrtc.so"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/libwebrtc.so"
   PARENT_SCOPE
 )
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,25 +1,135 @@
 include(ExternalProject)
 
-set(ZIPFILE "${CMAKE_CURRENT_LIST_DIR}/downloads/libwebrtc.zip")
-set(DOWNLOAD_URL "https://github.com/flutter-webrtc/flutter-webrtc/releases/download/v1.4.0/libwebrtc.zip")
+# Load binary version + download URL template from libwebrtc_version.ini so
+# bumping the prebuilt release does not require editing CMake.
+set(LIBWEBRTC_VERSION_INI "${CMAKE_CURRENT_LIST_DIR}/libwebrtc_version.ini")
+if(NOT EXISTS "${LIBWEBRTC_VERSION_INI}")
+  message(FATAL_ERROR "libwebrtc: missing version manifest at ${LIBWEBRTC_VERSION_INI}")
+endif()
+
+set(LIBWEBRTC_BINARY_VERSION "")
+set(LIBWEBRTC_DOWNLOAD_URL_BASE "")
+file(STRINGS "${LIBWEBRTC_VERSION_INI}" _libwebrtc_ini_lines)
+foreach(_line IN LISTS _libwebrtc_ini_lines)
+  string(STRIP "${_line}" _line)
+  # Skip blanks, comments (# or ;) and section headers ([name]).
+  if(_line STREQUAL "" OR _line MATCHES "^[#;]" OR _line MATCHES "^\\[.*\\]$")
+    continue()
+  endif()
+  if(NOT _line MATCHES "^([^=]+)=(.*)$")
+    continue()
+  endif()
+  string(STRIP "${CMAKE_MATCH_1}" _key)
+  string(STRIP "${CMAKE_MATCH_2}" _value)
+  if(_key STREQUAL "binary_version")
+    set(LIBWEBRTC_BINARY_VERSION "${_value}")
+  elseif(_key STREQUAL "download_url")
+    set(LIBWEBRTC_DOWNLOAD_URL_BASE "${_value}")
+  endif()
+endforeach()
+
+if(LIBWEBRTC_BINARY_VERSION STREQUAL "" OR LIBWEBRTC_DOWNLOAD_URL_BASE STREQUAL "")
+  message(FATAL_ERROR "libwebrtc: ${LIBWEBRTC_VERSION_INI} must define binary_version and download_url")
+endif()
+
+# Strip any trailing slashes so we control the separator when composing the URL.
+string(REGEX REPLACE "/+$" "" LIBWEBRTC_DOWNLOAD_URL_BASE "${LIBWEBRTC_DOWNLOAD_URL_BASE}")
+
+# Resolve OS field for the release asset name (win / linux)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  set(LIBWEBRTC_OS "win")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(LIBWEBRTC_OS "linux")
+else()
+  message(FATAL_ERROR "libwebrtc: unsupported target OS '${CMAKE_SYSTEM_NAME}'")
+endif()
+
+# Resolve arch field for the release asset name (x64 / arm64)
+if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  # Visual Studio generator exposes the selected arch via CMAKE_GENERATOR_PLATFORM
+  string(TOLOWER "${CMAKE_GENERATOR_PLATFORM}" _libwebrtc_plat)
+  if(_libwebrtc_plat STREQUAL "arm64")
+    set(LIBWEBRTC_ARCH "arm64")
+  elseif(_libwebrtc_plat STREQUAL "x64" OR _libwebrtc_plat STREQUAL "")
+    # Empty platform usually means Ninja/default x64 host build
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+      set(LIBWEBRTC_ARCH "x64")
+    else()
+      message(FATAL_ERROR "libwebrtc: 32-bit Windows is not supported")
+    endif()
+  else()
+    message(FATAL_ERROR "libwebrtc: unsupported Windows arch '${CMAKE_GENERATOR_PLATFORM}'")
+  endif()
+else()
+  # Flutter Linux / eLinux pass the target as e.g. linux-x64 or linux-arm64
+  if(DEFINED FLUTTER_TARGET_PLATFORM AND FLUTTER_TARGET_PLATFORM MATCHES "arm64")
+    set(LIBWEBRTC_ARCH "arm64")
+  elseif(DEFINED FLUTTER_TARGET_PLATFORM AND FLUTTER_TARGET_PLATFORM MATCHES "x64")
+    set(LIBWEBRTC_ARCH "x64")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(LIBWEBRTC_ARCH "arm64")
+  else()
+    set(LIBWEBRTC_ARCH "x64")
+  endif()
+endif()
+
+set(LIBWEBRTC_ASSET "libwebrtc-${LIBWEBRTC_OS}-${LIBWEBRTC_ARCH}-release")
+set(ZIPFILE "${CMAKE_CURRENT_LIST_DIR}/downloads/${LIBWEBRTC_ASSET}.zip")
+
+# Final URL = <base>/<binary_version>/<asset>.zip
+set(DOWNLOAD_URL "${LIBWEBRTC_DOWNLOAD_URL_BASE}/${LIBWEBRTC_BINARY_VERSION}/${LIBWEBRTC_ASSET}.zip")
+
+function(_libwebrtc_extract_and_normalize zip_path dest_dir)
+  # Extract into an isolated staging dir so we can normalize the top-level
+  # layout regardless of what folder name the archive uses (e.g.
+  # libwebrtc-linux-x64-release/ vs. libwebrtc/ vs. files at the root).
+  set(_staging "${dest_dir}/.libwebrtc_extract")
+  file(REMOVE_RECURSE "${_staging}")
+  file(MAKE_DIRECTORY "${_staging}")
+  file(ARCHIVE_EXTRACT INPUT "${zip_path}" DESTINATION "${_staging}")
+
+  if(EXISTS "${dest_dir}/libwebrtc")
+    file(REMOVE_RECURSE "${dest_dir}/libwebrtc")
+  endif()
+
+  file(GLOB _entries "${_staging}/*")
+  list(LENGTH _entries _entry_count)
+  set(_promoted FALSE)
+  if(_entry_count EQUAL 1)
+    list(GET _entries 0 _only)
+    if(IS_DIRECTORY "${_only}")
+      file(RENAME "${_only}" "${dest_dir}/libwebrtc")
+      set(_promoted TRUE)
+    endif()
+  endif()
+  if(NOT _promoted)
+    # Archive root holds the files directly — wrap them in libwebrtc/.
+    file(MAKE_DIRECTORY "${dest_dir}/libwebrtc")
+    foreach(_entry IN LISTS _entries)
+      get_filename_component(_name "${_entry}" NAME)
+      file(RENAME "${_entry}" "${dest_dir}/libwebrtc/${_name}")
+    endforeach()
+  endif()
+
+  file(REMOVE_RECURSE "${_staging}")
+endfunction()
 
 if(NOT EXISTS "${ZIPFILE}")
   message(NOTICE "download: ${DOWNLOAD_URL}")
-    file(DOWNLOAD "${DOWNLOAD_URL}"
-        ${ZIPFILE}
-        STATUS download_status
-        LOG download_log)
+  file(DOWNLOAD "${DOWNLOAD_URL}"
+      ${ZIPFILE}
+      STATUS download_status
+      LOG download_log)
 
-    if(NOT download_status EQUAL 0)
+  if(NOT download_status EQUAL 0)
     message(FATAL_ERROR "Failed to download dependency: ${download_log}")
-    endif()
+  endif()
 
-    file(ARCHIVE_EXTRACT INPUT ${ZIPFILE} DESTINATION "${CMAKE_CURRENT_LIST_DIR}")
+  _libwebrtc_extract_and_normalize("${ZIPFILE}" "${CMAKE_CURRENT_LIST_DIR}")
 else()
   if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/libwebrtc")
     message(NOTICE "libwebrtc directory does not exist after extraction.")
-    file(ARCHIVE_EXTRACT INPUT ${ZIPFILE} DESTINATION "${CMAKE_CURRENT_LIST_DIR}")
+    _libwebrtc_extract_and_normalize("${ZIPFILE}" "${CMAKE_CURRENT_LIST_DIR}")
   endif()
   message(TRACE "libwebrtc already downloaded.")
 endif()
-

--- a/third_party/libwebrtc_version.ini
+++ b/third_party/libwebrtc_version.ini
@@ -1,0 +1,7 @@
+# libwebrtc prebuilt binary release info.
+# See https://github.com/webrtc-sdk/libwebrtc/releases for available versions.
+# `download_url` is the base release-download URL; the version tag, asset name
+# and `.zip` suffix are appended at configure time by third_party/CMakeLists.txt.
+[libwebrtc]
+binary_version = libwebrtc.m144.7559.02
+download_url   = https://github.com/webrtc-sdk/libwebrtc/releases/download

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -52,11 +52,11 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE 
   flutter
   flutter_wrapper_plugin
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/win64/libwebrtc.dll.lib"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/libwebrtc.dll.lib"
 )
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(flutter_webrtc_bundled_libraries
-  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/win64/libwebrtc.dll"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../third_party/libwebrtc/lib/libwebrtc.dll"
   PARENT_SCOPE
 )


### PR DESCRIPTION
## Summary

Refactor `third_party/CMakeLists.txt` so the prebuilt libwebrtc download is driven by build context instead of hardcoded strings.

- Move `binary_version` and `download_url` (base) into `third_party/libwebrtc_version.ini`; CMake parses the INI at configure time.
- Auto-detect the target OS (`win` / `linux`) from `CMAKE_SYSTEM_NAME` and the arch (`x64` / `arm64`) from `CMAKE_GENERATOR_PLATFORM` on Windows or `FLUTTER_TARGET_PLATFORM` / `CMAKE_SYSTEM_PROCESSOR` on Linux/eLinux.
- Compose the release asset as `libwebrtc-<os>-<arch>-release.zip` and cache each variant separately under `third_party/downloads/`.
- Normalize the extracted layout: stage into a temp dir and force-rename the top-level folder to `libwebrtc/`, regardless of what the archive uses.

Bumping libwebrtc now only requires editing `libwebrtc_version.ini`.
