### PR TITLE
chore(android): migrate to built-in Kotlin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+[Unreleased]
+
+* [Android] Migrate to built-in Kotlin: skip `kotlin-android` apply when AGP >= 9 and use the `kotlin { compilerOptions {} }` DSL. Compatible with both pre- and post-Flutter 3.44 toolchains.
+
 [1.4.1] -2026-03-24
 
 * [Dart] fixed scalabilityMode (#2022).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,11 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -45,9 +49,11 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+}
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }
 


### PR DESCRIPTION
Conditionally apply the kotlin-android plugin only when AGP < 9 and
switch to the top-level `kotlin { compilerOptions {} }` DSL, per the
Flutter built-in Kotlin migration guide. Compatible with both
pre- and post-Flutter 3.44 toolchains.

close #2053