### PR TITLE
fix(desktop): map echoCancellation/noiseSuppression/autoGainControl constraints to RTCAudioOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+[Unreleased]
+
+* [Windows/Linux] fix: Map echoCancellation/noiseSuppression/autoGainControl constraints to RTCAudioOptions so software AEC/NS/AGC can actually be toggled from Dart (#XXXX).
+
 [1.4.1] -2026-03-24
 
 * [Dart] fixed scalabilityMode (#2022).

--- a/common/cpp/src/flutter_media_stream.cc
+++ b/common/cpp/src/flutter_media_stream.cc
@@ -90,6 +90,61 @@ void addDefaultAudioConstraints(
   audioConstraints->AddOptionalConstraint("googDAEchoCancellation", "true");
 }
 
+// Reads a boolean audio-processing flag from the audio constraint map.
+// Supports flat W3C keys, mandatory sub-map keys, and optional list entries
+// (each a single-pair map, the format used by the LiveKit SDK and others).
+// Accepts bool values or "true"/"false" strings. Falls back to defaultValue
+// when the key is absent (W3C default is true for AEC/NS/AGC).
+static bool getAudioProcessingFlag(const EncodableMap& audioMap,
+                                   const std::vector<std::string>& keys,
+                                   bool defaultValue) {
+  auto readBoolValue = [](const EncodableValue& v, bool def) -> bool {
+    if (TypeIs<bool>(v)) return GetValue<bool>(v);
+    if (TypeIs<std::string>(v)) {
+      const std::string& s = GetValue<std::string>(v);
+      if (s == "true") return true;
+      if (s == "false") return false;
+    }
+    return def;
+  };
+
+  for (const std::string& key : keys) {
+    // Flat W3C key at the top level.
+    auto it = audioMap.find(EncodableValue(key));
+    if (it != audioMap.end()) {
+      return readBoolValue(it->second, defaultValue);
+    }
+
+    // Inside "mandatory" sub-map.
+    auto mandatoryIt = audioMap.find(EncodableValue("mandatory"));
+    if (mandatoryIt != audioMap.end() &&
+        TypeIs<EncodableMap>(mandatoryIt->second)) {
+      const EncodableMap& mandatory =
+          GetValue<EncodableMap>(mandatoryIt->second);
+      auto mit = mandatory.find(EncodableValue(key));
+      if (mit != mandatory.end()) {
+        return readBoolValue(mit->second, defaultValue);
+      }
+    }
+
+    // Inside "optional" list — each entry is a single-pair map.
+    auto optionalIt = audioMap.find(EncodableValue("optional"));
+    if (optionalIt != audioMap.end() &&
+        TypeIs<EncodableList>(optionalIt->second)) {
+      const EncodableList& list = GetValue<EncodableList>(optionalIt->second);
+      for (const EncodableValue& item : list) {
+        if (!TypeIs<EncodableMap>(item)) continue;
+        const EncodableMap& entry = GetValue<EncodableMap>(item);
+        auto eit = entry.find(EncodableValue(key));
+        if (eit != entry.end()) {
+          return readBoolValue(eit->second, defaultValue);
+        }
+      }
+    }
+  }
+  return defaultValue;
+}
+
 std::string getSourceIdConstraint(const EncodableMap& mediaConstraints) {
   auto it = mediaConstraints.find(EncodableValue("optional"));
   if (it != mediaConstraints.end() && TypeIs<EncodableList>(it->second)) {
@@ -120,6 +175,7 @@ void FlutterMediaStream::GetUserAudio(const EncodableMap& constraints,
                                       EncodableMap& params) {
   bool enable_audio = false;
   scoped_refptr<RTCMediaConstraints> audioConstraints;
+  RTCAudioOptions audio_options;
   std::string sourceId;
   std::string deviceId;
   auto it = constraints.find(EncodableValue("audio"));
@@ -131,6 +187,11 @@ void FlutterMediaStream::GetUserAudio(const EncodableMap& constraints,
       enable_audio = GetValue<bool>(audio);
       sourceId = "";
       deviceId = "";
+      // audio: true — keep software processing on (W3C/WebRTC default).
+      audio_options.echo_cancellation = true;
+      audio_options.noise_suppression = true;
+      audio_options.auto_gain_control = true;
+      audio_options.highpass_filter = false;
     }
     if (TypeIs<EncodableMap>(audio)) {
       EncodableMap localMap = GetValue<EncodableMap>(audio);
@@ -138,6 +199,16 @@ void FlutterMediaStream::GetUserAudio(const EncodableMap& constraints,
       deviceId = getDeviceIdConstraint(localMap);
       audioConstraints = base_->ParseMediaConstraints(localMap);
       enable_audio = true;
+      // Map W3C/goog-prefixed constraint keys to RTCAudioOptions so the
+      // software AEC/NS/AGC can actually be toggled from the Dart side.
+      audio_options.echo_cancellation = getAudioProcessingFlag(
+          localMap, {"echoCancellation", "googEchoCancellation"}, true);
+      audio_options.noise_suppression = getAudioProcessingFlag(
+          localMap, {"noiseSuppression", "googNoiseSuppression"}, true);
+      audio_options.auto_gain_control = getAudioProcessingFlag(
+          localMap, {"autoGainControl", "googAutoGainControl"}, true);
+      audio_options.highpass_filter = getAudioProcessingFlag(
+          localMap, {"highpassFilter", "googHighpassFilter"}, false);
     }
   }
 
@@ -181,8 +252,8 @@ void FlutterMediaStream::GetUserAudio(const EncodableMap& constraints,
       }
     }
 
-    scoped_refptr<RTCAudioSource> source =
-        base_->factory_->CreateAudioSource("audio_input");
+    scoped_refptr<RTCAudioSource> source = base_->factory_->CreateAudioSource(
+        "audio_input", RTCAudioSource::SourceType::kMicrophone, audio_options);
     std::string uuid = base_->GenerateUUID();
     scoped_refptr<RTCAudioTrack> track =
         base_->factory_->CreateAudioTrack(source, uuid.c_str());
@@ -201,9 +272,12 @@ void FlutterMediaStream::GetUserAudio(const EncodableMap& constraints,
     settings[EncodableValue("deviceId")] =
         EncodableValue(SanitizeUtf8ForFlutter(sourceId));
     settings[EncodableValue("kind")] = EncodableValue("audioinput");
-    settings[EncodableValue("autoGainControl")] = EncodableValue(true);
-    settings[EncodableValue("echoCancellation")] = EncodableValue(true);
-    settings[EncodableValue("noiseSuppression")] = EncodableValue(true);
+    settings[EncodableValue("autoGainControl")] =
+        EncodableValue(audio_options.auto_gain_control);
+    settings[EncodableValue("echoCancellation")] =
+        EncodableValue(audio_options.echo_cancellation);
+    settings[EncodableValue("noiseSuppression")] =
+        EncodableValue(audio_options.noise_suppression);
     settings[EncodableValue("channelCount")] = EncodableValue(1);
     settings[EncodableValue("latency")] = EncodableValue(0);
     track_info[EncodableValue("settings")] = EncodableValue(settings);


### PR DESCRIPTION
Fixes #2067

## Problem

Since 1.2.1 the software APM (AEC/NS/AGC) is unconditionally enabled on Linux/Windows/eLinux. The `echoCancellation`, `noiseSuppression`, and `autoGainControl` constraint keys are parsed into an `RTCMediaConstraints` object that is then silently discarded. `CreateAudioSource` is called without an `RTCAudioOptions` argument, so all three processing stages default to `true` regardless of the Dart caller's intent.

`getSettings()` also hardcoded `true` for all three flags, masking the issue.

## Fix

- Add `getAudioProcessingFlag()`: resolves a boolean flag from all three constraint shapes — flat W3C key, `mandatory` sub-map, `optional` list entries (the format the LiveKit SDK and others use).
- Populate an `RTCAudioOptions` struct from the resolved values and pass it to `CreateAudioSource`.
- For the `audio: true` (boolean) path, keep all processing on to preserve existing behaviour.
- Report the actual constraint values in `getSettings()`.

Only `common/cpp/src/flutter_media_stream.cc` is changed — shared by Linux, Windows, and eLinux.

## Test procedure

1. On Linux (Ubuntu with PipeWire or PulseAudio), call `getUserMedia` with `echoCancellation: false`.
2. Play audio through speakers while recording — echo should be audible in the captured stream.
3. Repeat with `echoCancellation: true` — echo should be suppressed by the software AEC.
4. Verify `track.getSettings()['echoCancellation']` returns the value passed in the constraint.