### PR TITLE
feat(audio): allow embedders to own audio session management

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation 'io.github.webrtc-sdk:android:144.7559.04'
-    implementation 'com.github.davidliu:audioswitch:89582c47c9a04c62f90aa5e57251af4800a62c9a'
+    implementation 'com.github.davidliu:audioswitch:039a35aefab7747c557242fa216c9ea11743b604'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
 
 dependencies {
     implementation 'io.github.webrtc-sdk:android:144.7559.04'
-    implementation 'com.github.davidliu:audioswitch:039a35aefab7747c557242fa216c9ea11743b604'
+    implementation 'com.github.davidliu:audioswitch:89582c47c9a04c62f90aa5e57251af4800a62c9a'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
@@ -55,6 +55,14 @@ public class AudioSwitchManager {
     private AudioSwitch audioSwitch;
 
     /**
+     * When false, FlutterWebRTC will not create AudioSwitch or mutate Android audio mode,
+     * focus, or routing. Process-global and intended to be set once from native code (e.g.
+     * another plugin) before any audio op; defaults to enabled. See
+     * {@link #setAudioSessionManagementEnabled(boolean)}.
+     */
+    private static boolean audioSessionManagementEnabled = true;
+
+    /**
      * When true, AudioSwitchManager will request audio focus on start and abandon on stop.
      * <br />
      * Defaults to true.
@@ -130,41 +138,46 @@ public class AudioSwitchManager {
         preferredDeviceList.add(AudioDevice.WiredHeadset.class);
         preferredDeviceList.add(AudioDevice.Speakerphone.class);
         preferredDeviceList.add(AudioDevice.Earpiece.class);
-        initAudioSwitch();
     }
 
-    private void initAudioSwitch() {
-        if (audioSwitch == null) {
-            handler.removeCallbacksAndMessages(null);
-            handler.postAtFrontOfQueue(() -> {
-                audioSwitch = new AudioSwitch(
-                        context,
-                        loggingEnabled,
-                        audioFocusChangeListener,
-                        preferredDeviceList
-                );
-                audioSwitch.setManageAudioFocus(manageAudioFocus);
-                audioSwitch.setFocusMode(focusMode);
-                audioSwitch.setAudioMode(audioMode);
-                audioSwitch.setAudioStreamType(audioStreamType);
-                audioSwitch.setAudioAttributeContentType(audioAttributeContentType);
-                audioSwitch.setAudioAttributeUsageType(audioAttributeUsageType);
-                audioSwitch.setForceHandleAudioRouting(forceHandleAudioRouting);
-                audioSwitch.start(audioDeviceChangeListener);
-            });
+    @Nullable
+    private AudioSwitch getOrCreateAudioSwitch() {
+        if (!audioSessionManagementEnabled) {
+            return null;
         }
+
+        if (audioSwitch == null) {
+            audioSwitch = new AudioSwitch(
+                    context,
+                    loggingEnabled,
+                    audioFocusChangeListener,
+                    preferredDeviceList
+            );
+            audioSwitch.setManageAudioFocus(manageAudioFocus);
+            audioSwitch.setFocusMode(focusMode);
+            audioSwitch.setAudioMode(audioMode);
+            audioSwitch.setAudioStreamType(audioStreamType);
+            audioSwitch.setAudioAttributeContentType(audioAttributeContentType);
+            audioSwitch.setAudioAttributeUsageType(audioAttributeUsageType);
+            audioSwitch.setForceHandleAudioRouting(forceHandleAudioRouting);
+            audioSwitch.start(audioDeviceChangeListener);
+        }
+
+        return audioSwitch;
     }
 
     public void start() {
-        if (audioSwitch != null) {
-            handler.removeCallbacksAndMessages(null);
-            handler.postAtFrontOfQueue(() -> {
-                if (!isActive) {
-                    Objects.requireNonNull(audioSwitch).activate();
-                    isActive = true;
-                }
-            });
+        if (!audioSessionManagementEnabled) {
+            return;
         }
+        handler.removeCallbacksAndMessages(null);
+        handler.postAtFrontOfQueue(() -> {
+            AudioSwitch audioSwitch = getOrCreateAudioSwitch();
+            if (audioSwitch != null && !isActive) {
+                audioSwitch.activate();
+                isActive = true;
+            }
+        });
     }
 
     public void stop() {
@@ -179,23 +192,38 @@ public class AudioSwitchManager {
         }
     }
 
+    public static void setAudioSessionManagementEnabled(boolean enabled) {
+        audioSessionManagementEnabled = enabled;
+    }
+
     public void setMicrophoneMute(boolean mute) {
         audioManager.setMicrophoneMute(mute);
     }
 
     @Nullable
     public AudioDevice selectedAudioDevice() {
-        return Objects.requireNonNull(audioSwitch).getSelectedAudioDevice();
+        AudioSwitch audioSwitch = getOrCreateAudioSwitch();
+        return audioSwitch == null ? null : audioSwitch.getSelectedAudioDevice();
     }
 
     @NonNull
     public List<AudioDevice> availableAudioDevices() {
-        return Objects.requireNonNull(audioSwitch).getAvailableAudioDevices();
+        AudioSwitch audioSwitch = getOrCreateAudioSwitch();
+        return audioSwitch == null ? new ArrayList<>() : audioSwitch.getAvailableAudioDevices();
     }
 
     public void selectAudioOutput(@NonNull Class<? extends AudioDevice> audioDeviceClass) {
+        if (!audioSessionManagementEnabled) {
+            return;
+        }
+
         handler.post(() -> {
-            List<AudioDevice> devices = availableAudioDevices();
+            AudioSwitch audioSwitch = getOrCreateAudioSwitch();
+            if (audioSwitch == null) {
+                return;
+            }
+
+            List<AudioDevice> devices = audioSwitch.getAvailableAudioDevices();
             AudioDevice audioDevice = null;
             for (AudioDevice device : devices) {
                 if (device.getClass().equals(audioDeviceClass)) {
@@ -204,12 +232,16 @@ public class AudioSwitchManager {
                 }
             }
             if (audioDevice != null) {
-                Objects.requireNonNull(audioSwitch).selectDevice(audioDevice);
+                audioSwitch.selectDevice(audioDevice);
             }
         });
     }
 
     private void updatePreferredDeviceList(boolean speakerOn) {
+        if (!audioSessionManagementEnabled) {
+            return;
+        }
+
         preferredDeviceList = new ArrayList<>();
         preferredDeviceList.add(AudioDevice.BluetoothHeadset.class);
         preferredDeviceList.add(AudioDevice.WiredHeadset.class);
@@ -221,11 +253,18 @@ public class AudioSwitchManager {
             preferredDeviceList.add(AudioDevice.Speakerphone.class);
         }
         handler.post(() -> {
-            Objects.requireNonNull(audioSwitch).setPreferredDeviceList(preferredDeviceList);
+            AudioSwitch audioSwitch = getOrCreateAudioSwitch();
+            if (audioSwitch != null) {
+                audioSwitch.setPreferredDeviceList(preferredDeviceList);
+            }
         });
     }
 
     public void enableSpeakerphone(boolean enable) {
+        if (!audioSessionManagementEnabled) {
+            return;
+        }
+
         updatePreferredDeviceList(enable);
         if (enable) {
             selectAudioOutput(AudioDevice.Speakerphone.class);
@@ -248,13 +287,20 @@ public class AudioSwitchManager {
                 selectAudioOutput(audioDevice.getClass());
             } else {
                 handler.post(() -> {
-                    Objects.requireNonNull(audioSwitch).selectDevice(null);
+                    AudioSwitch audioSwitch = getOrCreateAudioSwitch();
+                    if (audioSwitch != null) {
+                        audioSwitch.selectDevice(null);
+                    }
                 });
             }
         }
     }
 
     public void enableSpeakerButPreferBluetooth() {
+        if (!audioSessionManagementEnabled) {
+            return;
+        }
+
         List<AudioDevice> devices = availableAudioDevices();
         AudioDevice audioDevice = null;
         for (AudioDevice device : devices) {
@@ -281,7 +327,7 @@ public class AudioSwitchManager {
     }
 
     public void setAudioConfiguration(Map<String, Object> configuration) {
-        if (configuration == null) {
+        if (configuration == null || !audioSessionManagementEnabled) {
             return;
         }
 
@@ -329,9 +375,11 @@ public class AudioSwitchManager {
     }
 
     public void setManageAudioFocus(@Nullable Boolean manage) {
-        if (manage != null && audioSwitch != null) {
+        if (manage != null) {
             this.manageAudioFocus = manage;
-            Objects.requireNonNull(audioSwitch).setManageAudioFocus(this.manageAudioFocus);
+            if (audioSwitch != null) {
+                audioSwitch.setManageAudioFocus(this.manageAudioFocus);
+            }
         }
     }
 
@@ -396,14 +444,16 @@ public class AudioSwitchManager {
     }
 
     public void setForceHandleAudioRouting(@Nullable Boolean force) {
-        if (force != null && audioSwitch != null) {
+        if (force != null) {
             this.forceHandleAudioRouting = force;
-            Objects.requireNonNull(audioSwitch).setForceHandleAudioRouting(this.forceHandleAudioRouting);
+            if (audioSwitch != null) {
+                audioSwitch.setForceHandleAudioRouting(this.forceHandleAudioRouting);
+            }
         }
     }
 
     public void clearCommunicationDevice() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (audioSessionManagementEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             audioManager.clearCommunicationDevice();
         }
     }

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -761,6 +761,12 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
   }
 #endif
 #if TARGET_OS_IPHONE
+  if (!self.audioSessionManagementEnabled) {
+    if (result)
+      result(nil);
+    return;
+  }
+
   RTCAudioSession* session = [RTCAudioSession sharedInstance];
   for (AVAudioSessionPortDescription* port in session.session.availableInputs) {
     if ([port.UID isEqualToString:deviceId]) {
@@ -793,6 +799,11 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
   }
 #endif
 #if TARGET_OS_IPHONE
+  if (!self.audioSessionManagementEnabled) {
+    result(nil);
+    return;
+  }
+
   RTCAudioSession* session = [RTCAudioSession sharedInstance];
   NSError* setCategoryError = nil;
 

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -71,6 +71,14 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 /// Defaults to YES.
 + (void)setAudioSessionManagementEnabled:(BOOL)enabled;
 
+/// Register a delegate to receive the audio device module's engine-lifecycle
+/// callbacks. Intended to be set once from native code (e.g. another plugin's
+/// registration) before the peer connection factory is created, so the
+/// embedder can own audio-session policy. Held weakly — the caller must retain
+/// the delegate. When set, it takes over the audio device module's `observer`
+/// slot; when unset, the plugin's default observer behavior is unchanged.
++ (void)setAudioDeviceModuleObserver:(id<RTCAudioDeviceModuleDelegate> _Nullable)observer;
+
 @property(nonatomic) BOOL _usingFrontCamera;
 @property(nonatomic) NSInteger _lastTargetWidth;
 @property(nonatomic) NSInteger _lastTargetHeight;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -63,6 +63,14 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 @property(nonatomic, strong) NSString* _Nonnull focusMode;
 @property(nonatomic, strong) NSString* _Nonnull exposureMode;
 
+@property(nonatomic, readonly) BOOL audioSessionManagementEnabled;
+
+/// Globally enable/disable Flutter WebRTC's own platform audio-session
+/// management (category/mode/focus/routing). Intended to be set once from
+/// native code (e.g. another plugin's registration) before any audio op.
+/// Defaults to YES.
++ (void)setAudioSessionManagementEnabled:(BOOL)enabled;
+
 @property(nonatomic) BOOL _usingFrontCamera;
 @property(nonatomic) NSInteger _lastTargetWidth;
 @property(nonatomic) NSInteger _lastTargetHeight;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -126,12 +126,25 @@ void postEvent(FlutterEventSink _Nullable sink, id _Nullable event) {
 
 static FlutterWebRTCPlugin *sharedSingleton;
 
+// Process-global so it can be set from native code (e.g. another plugin) before
+// this plugin is even registered. Defaults to enabled. See
+// +setAudioSessionManagementEnabled:.
+static BOOL gAudioSessionManagementEnabled = YES;
+
 + (FlutterWebRTCPlugin *)sharedSingleton
 {
   @synchronized(self)
   {
     return sharedSingleton;
   }
+}
+
++ (void)setAudioSessionManagementEnabled:(BOOL)enabled {
+  gAudioSessionManagementEnabled = enabled;
+}
+
+- (BOOL)audioSessionManagementEnabled {
+  return gAudioSessionManagementEnabled;
 }
 
 @synthesize messenger = _messenger;
@@ -1134,8 +1147,10 @@ static FlutterWebRTCPlugin *sharedSingleton;
     NSNumber* enable = argsMap[@"enable"];
     _speakerOn = enable.boolValue;
     _speakerOnButPreferBluetooth = NO;
-    [AudioUtils setSpeakerphoneOn:_speakerOn];
-    postEvent(self.eventSink, @{@"event" : @"onDeviceChange"});
+    if (self.audioSessionManagementEnabled) {
+      [AudioUtils setSpeakerphoneOn:_speakerOn];
+      postEvent(self.eventSink, @{@"event" : @"onDeviceChange"});
+    }
     result(nil);
   }
   else if ([@"ensureAudioSession" isEqualToString:call.method]) {
@@ -1145,13 +1160,17 @@ static FlutterWebRTCPlugin *sharedSingleton;
   else if ([@"enableSpeakerphoneButPreferBluetooth" isEqualToString:call.method]) {
     _speakerOn = YES;
     _speakerOnButPreferBluetooth = YES;
-    [AudioUtils setSpeakerphoneOnButPreferBluetooth];
+    if (self.audioSessionManagementEnabled) {
+      [AudioUtils setSpeakerphoneOnButPreferBluetooth];
+    }
     result(nil);
   }
   else if([@"setAppleAudioConfiguration" isEqualToString:call.method]) {
     NSDictionary* argsMap = call.arguments;
     NSDictionary* configuration = argsMap[@"configuration"];
-    [AudioUtils setAppleAudioConfiguration:configuration];
+    if (self.audioSessionManagementEnabled) {
+      [AudioUtils setAppleAudioConfiguration:configuration];
+    }
     result(nil);
   }
 #endif
@@ -1743,12 +1762,18 @@ static FlutterWebRTCPlugin *sharedSingleton;
 
 - (void)ensureAudioSession {
 #if TARGET_OS_IPHONE
+  if (!self.audioSessionManagementEnabled) {
+    return;
+  }
   [AudioUtils ensureAudioSessionWithRecording:[self hasLocalAudioTrack]];
 #endif
 }
 
 - (void)deactiveRtcAudioSession {
 #if TARGET_OS_IPHONE
+  if (!self.audioSessionManagementEnabled) {
+    return;
+  }
   if (![self hasLocalAudioTrack] && self.peerConnections.count == 0) {
     [AudioUtils deactiveRtcAudioSession];
   }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -131,6 +131,12 @@ static FlutterWebRTCPlugin *sharedSingleton;
 // +setAudioSessionManagementEnabled:.
 static BOOL gAudioSessionManagementEnabled = YES;
 
+// Process-global RTCAudioDeviceModuleDelegate, set by an embedding plugin
+// (e.g. livekit_client) before the factory is created so it can own the audio
+// device module's engine-lifecycle callbacks. Held weakly — the embedder
+// retains it. See +setAudioDeviceModuleObserver:.
+static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
+
 + (FlutterWebRTCPlugin *)sharedSingleton
 {
   @synchronized(self)
@@ -141,6 +147,10 @@ static BOOL gAudioSessionManagementEnabled = YES;
 
 + (void)setAudioSessionManagementEnabled:(BOOL)enabled {
   gAudioSessionManagementEnabled = enabled;
+}
+
++ (void)setAudioDeviceModuleObserver:(id<RTCAudioDeviceModuleDelegate>)observer {
+  gAudioDeviceModuleObserver = observer;
 }
 
 - (BOOL)audioSessionManagementEnabled {
@@ -339,6 +349,13 @@ static BOOL gAudioSessionManagementEnabled = YES;
                                                              encoderFactory:simulcastFactory
                                                              decoderFactory:decoderFactory
                                                       audioProcessingModule:_audioManager.audioProcessingModule];
+
+        // Allow an embedding plugin (e.g. livekit_client) to own the audio
+        // device module's engine-lifecycle delegate. Only override the observer
+        // when one is registered, leaving default behavior unchanged otherwise.
+        if (gAudioDeviceModuleObserver != nil) {
+            _peerConnectionFactory.audioDeviceModule.observer = gAudioDeviceModuleObserver;
+        }
 
 #if TARGET_OS_OSX
         // CoreAudio ADM requires explicit device initialization on macOS


### PR DESCRIPTION
## Motivation

When FlutterWebRTC is embedded alongside another SDK that wants to own the platform audio session (e.g. LiveKit) — the `AVAudioSession` category/mode/route on iOS, or the audio mode/focus/routing on Android — FlutterWebRTC's own session management conflicts with it.

This PR adds an **opt-in** way for an embedder to take over, with **no behavior change** for anyone who doesn't opt in.

## What's added

**1. Disable FlutterWebRTC's own audio session management**

- iOS: `+ [FlutterWebRTCPlugin setAudioSessionManagementEnabled:]`
- Android: `AudioSwitchManager.setAudioSessionManagementEnabled(boolean)`

When disabled, FlutterWebRTC no longer touches the `AVAudioSession` / `AudioSwitch` (category, mode, focus, routing, speaker). Microphone mute is intentionally left working. On Android the `AudioSwitch` is now created lazily and is never created while disabled.

**2. Expose the audio device module delegate (darwin)**

- `+ [FlutterWebRTCPlugin setAudioDeviceModuleObserver:]`

Lets an embedder receive the audio engine lifecycle callbacks (`willEnableEngine` / `didDisableEngine` / …) and drive audio-session policy from real engine events. Held weakly and wired onto the peer connection factory's audio device module at creation time; only overrides the observer when one is registered.

## Compatibility

Both switches default to **enabled** (`YES` / `true`), so existing consumers are unaffected. They are process-global statics intended to be set once from native code (e.g. another plugin's registration) before any audio operation.

## Usage

```objc
// iOS — from the embedding plugin's registration, before any audio op:
[FlutterWebRTCPlugin setAudioSessionManagementEnabled:NO];
[FlutterWebRTCPlugin setAudioDeviceModuleObserver:myDelegate];
```

```java
// Android
AudioSwitchManager.setAudioSessionManagementEnabled(false);
```

## Other

Bumps `com.github.davidliu:audioswitch` to `039a35a…`, the revision that exposes `CommDeviceAudioSwitch`, to align with downstream consumers.

## Platforms

iOS + Android (management switch); iOS/darwin (ADM delegate hook). macOS unchanged.
