### PR TITLE
fix: call SetRecordingDevice(0) when no sourceId is supplied

### DIFF
--- a/common/cpp/src/flutter_media_stream.cc
+++ b/common/cpp/src/flutter_media_stream.cc
@@ -237,6 +237,7 @@ void FlutterMediaStream::GetUserAudio(const EncodableMap& constraints,
                                                 strRecordingGuid);
       sourceId = SanitizeDeviceIdFromAudioBuffers(strRecordingName,
                                                   strRecordingGuid);
+      base_->audio_device_->SetRecordingDevice(0);
     }
 
     char strPlayoutName[256];


### PR DESCRIPTION
**Problem**

When `getUserMedia` is called without a `sourceId` constraint, the fallback path enters `if (sourceId == "")` at [`flutter_media_stream.cc:235`](https://github.com/Noobidoo/flutter-webrtc/blob/3054cffda98ab1feaa5126c84b2c43173968a929/common/cpp/src/flutter_media_stream.cc#L235), fetches the default device name and GUID, but never calls `SetRecordingDevice(0)`. No recording device is explicitly selected, which can cause the wrong device to be used or no audio to be captured.

**Fix**

Add `base_->audio_device_->SetRecordingDevice(0)` to the fallback block to ensure the default recording device is selected.

Fixes #2071