### PR TITLE
feat(android): expose the peer connection factory to embedders

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -18,6 +18,7 @@ import com.cloudwebrtc.webrtc.utils.ConstraintsMap;
 
 import org.webrtc.ExternalAudioProcessingFactory;
 import org.webrtc.MediaStreamTrack;
+import org.webrtc.PeerConnectionFactory;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -67,6 +68,10 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
 
     public MediaStreamTrack getRemoteTrack(String trackId) {
         return methodCallHandler.getRemoteTrack(trackId);
+    }
+
+    public PeerConnectionFactory getPeerConnectionFactory() {
+        return methodCallHandler.getPeerConnectionFactory();
     }
 
     @Override


### PR DESCRIPTION
## What

Adds a public `getPeerConnectionFactory()` accessor on the Android `FlutterWebRTCPlugin`, forwarding to the existing factory held by `MethodCallHandlerImpl`.

## Why

Native plugins that interop with flutter_webrtc sometimes need the shared `PeerConnectionFactory` to call factory-scoped WebRTC APIs. On iOS this is already possible since `FlutterWebRTCPlugin` exposes `peerConnectionFactory` as a public property, but on Android the factory is private to the method call handler. This adds the missing counterpart so both platforms behave the same.

Concrete example: WebRTC-SDK exposes engine-wide state on the factory (e.g. `PeerConnectionFactory.getAudioProcessingState()` in 144.7559.09), and the LiveKit Flutter SDK reads it through this accessor.

## Notes

- 5 lines + 1 import, no behavior change, nothing else touched.
- `getPeerConnectionFactory()` on `MethodCallHandlerImpl` already exists, this only makes it reachable from the plugin instance.