### PR TITLE
chore(deps): bump WebRTC-SDK to 144.7559.09 and libwebrtc to m144.7559.09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 [Unreleased]
 
+* [Darwin/Android] Bump WebRTC-SDK to 144.7559.09 (audio processing state v2, webrtc-sdk/webrtc#254).
+* [Windows/Linux] Bump prebuilt libwebrtc to libwebrtc.m144.7559.09.
 * [Android] Support AGP 9's built-in Kotlin: apply the Kotlin Gradle Plugin only when built-in Kotlin is inactive (AGP < 9, or AGP 9 with `android.builtInKotlin=false`), set the JVM target through the `kotlin { compilerOptions {} }` DSL when available, and fall back to the legacy `kotlinOptions` DSL for apps still on Kotlin Gradle Plugin 1.8.x.
 * [Windows/Linux] fix: Map echoCancellation/noiseSuppression/autoGainControl constraints to RTCAudioOptions so software AEC/NS/AGC can actually be toggled from Dart (#XXXX).
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ if (kotlinExt?.hasProperty('compilerOptions')) {
 }
 
 dependencies {
-    implementation 'io.github.webrtc-sdk:android:144.7559.04'
+    implementation 'io.github.webrtc-sdk:android:144.7559.09'
     implementation 'com.github.davidliu:audioswitch:89582c47c9a04c62f90aa5e57251af4800a62c9a'
     implementation 'androidx.annotation:annotation:1.1.0'
 }

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1736,7 +1736,7 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
       });
     } else if ([@"isVoiceProcessingEnabled" isEqualToString:call.method]) {
       RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
-      NSNumber* admResult = [NSNumber numberWithBool:adm.isVoiceProcessingEnabled];
+      NSNumber* admResult = [NSNumber numberWithBool:adm.isPlatformVoiceProcessingAllowed];
       result(admResult);
     } else if ([@"isVoiceProcessingBypassed" isEqualToString:call.method]) {
       RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'WebRTC-SDK', '144.7559.04'
+  s.dependency 'WebRTC-SDK', '144.7559.09'
   s.ios.deployment_target = '13.0'
   s.static_framework = true
   s.pod_target_xcconfig = {

--- a/macos/flutter_webrtc.podspec
+++ b/macos/flutter_webrtc.podspec
@@ -16,6 +16,6 @@ A new flutter plugin project.
 
   s.dependency 'FlutterMacOS'
   s.weak_frameworks = 'ScreenCaptureKit'
-  s.dependency 'WebRTC-SDK', '144.7559.04'
+  s.dependency 'WebRTC-SDK', '144.7559.09'
   s.osx.deployment_target = '10.15'
 end

--- a/third_party/libwebrtc_version.ini
+++ b/third_party/libwebrtc_version.ini
@@ -3,5 +3,5 @@
 # `download_url` is the base release-download URL; the version tag, asset name
 # and `.zip` suffix are appended at configure time by third_party/CMakeLists.txt.
 [libwebrtc]
-binary_version = libwebrtc.m144.7559.02
+binary_version = libwebrtc.m144.7559.09
 download_url   = https://github.com/webrtc-sdk/libwebrtc/releases/download


### PR DESCRIPTION
## What

Bumps all prebuilt WebRTC binaries to the M144.7559.09 line, built from webrtc-sdk/webrtc@b1800a61db8320af5c14456c13622d8b85b1ed39:

- **Android** (maven `io.github.webrtc-sdk:android`): `144.7559.04` → `144.7559.09`
- **iOS / macOS** (CocoaPods `WebRTC-SDK`): `144.7559.04` → `144.7559.09`
- **Windows / Linux** (prebuilt libwebrtc via `third_party/libwebrtc_version.ini`): `libwebrtc.m144.7559.02` → `libwebrtc.m144.7559.09` — first bump through the ini mechanism from #2061

Coming from `.04`, this picks up the runtime audio processing options API (webrtc-sdk/webrtc#247) and the factory-owned audio processing state v2 (webrtc-sdk/webrtc#254), among everything else in `.05`–`.09`.

## API migration

One ADM property was renamed in 144.7559.09: `RTCAudioDeviceModule.isVoiceProcessingEnabled` is now `isPlatformVoiceProcessingAllowed`. The single call site is migrated; the Dart-facing `isVoiceProcessingEnabled` method-channel name is unchanged. Other WebRTC-SDK consumers using the old property will need the same one-line change when they bump.

## Draft until

- [x] CocoaPods `WebRTC-SDK 144.7559.09` on trunk
- [x] maven `io.github.webrtc-sdk:android:144.7559.09` published (webrtc-sdk/android#49)
- [x] `libwebrtc.m144.7559.09` release assets attached

All artifacts are published — ready for review.


