### PR TITLE
feat(android): add fullScreenOnly option to requestCapturePermission (force entire-screen on API 34+)

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -13,6 +13,7 @@ import android.graphics.Point;
 import android.hardware.camera2.CameraManager;
 import android.media.AudioDeviceInfo;
 import android.media.projection.MediaProjection;
+import android.media.projection.MediaProjectionConfig;
 import android.media.projection.MediaProjectionManager;
 import android.net.Uri;
 import android.os.Build;
@@ -100,6 +101,7 @@ public class GetUserMediaImpl {
     private static final String PROJECTION_DATA = "PROJECTION_DATA";
     private static final String RESULT_RECEIVER = "RESULT_RECEIVER";
     private static final String REQUEST_CODE = "REQUEST_CODE";
+    private static final String FULL_SCREEN_ONLY = "FULL_SCREEN_ONLY";
 
     static final String TAG = FlutterWebRTCPlugin.TAG;
 
@@ -120,6 +122,10 @@ public class GetUserMediaImpl {
 
 
     public void screenRequestPermissions(ResultReceiver resultReceiver) {
+        screenRequestPermissions(resultReceiver, false);
+    }
+
+    public void screenRequestPermissions(ResultReceiver resultReceiver, boolean fullScreenOnly) {
         mediaProjectionData = null;
         final Activity activity = stateProvider.getActivity();
         if (activity == null) {
@@ -130,6 +136,7 @@ public class GetUserMediaImpl {
         Bundle args = new Bundle();
         args.putParcelable(RESULT_RECEIVER, resultReceiver);
         args.putInt(REQUEST_CODE, CAPTURE_PERMISSION_REQUEST_CODE);
+        args.putBoolean(FULL_SCREEN_ONLY, fullScreenOnly);
 
         ScreenRequestPermissionsFragment fragment = new ScreenRequestPermissionsFragment();
         fragment.setArguments(args);
@@ -148,6 +155,10 @@ public class GetUserMediaImpl {
     }
 
     public void requestCapturePermission(final Result result) {
+        requestCapturePermission(result, false);
+    }
+
+    public void requestCapturePermission(final Result result, final boolean fullScreenOnly) {
         screenRequestPermissions(
                 new ResultReceiver(new Handler(Looper.getMainLooper())) {
                     @Override
@@ -160,7 +171,8 @@ public class GetUserMediaImpl {
                             result.success(false);
                         }
                     }
-                });
+                },
+                fullScreenOnly);
     }
 
     public static class ScreenRequestPermissionsFragment extends Fragment {
@@ -175,11 +187,12 @@ public class GetUserMediaImpl {
                 Bundle args = getArguments();
                 resultReceiver = args.getParcelable(RESULT_RECEIVER);
                 requestCode = args.getInt(REQUEST_CODE);
-                requestStart(activity, requestCode);
+                boolean fullScreenOnly = args.getBoolean(FULL_SCREEN_ONLY, false);
+                requestStart(activity, requestCode, fullScreenOnly);
             }
         }
 
-        public void requestStart(Activity activity, int requestCode) {
+        public void requestStart(Activity activity, int requestCode, boolean fullScreenOnly) {
             if (android.os.Build.VERSION.SDK_INT < minAPILevel) {
                 Log.w(
                         TAG,
@@ -188,9 +201,21 @@ public class GetUserMediaImpl {
                 MediaProjectionManager mediaProjectionManager =
                         (MediaProjectionManager) activity.getSystemService(Context.MEDIA_PROJECTION_SERVICE);
 
+                // On Android 14+ (API 34), opt in to capturing the entire display so the
+                // consent dialog no longer offers the single-app option.
+                Intent captureIntent;
+                if (fullScreenOnly
+                        && android.os.Build.VERSION.SDK_INT
+                                >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                    captureIntent =
+                            mediaProjectionManager.createScreenCaptureIntent(
+                                    MediaProjectionConfig.createConfigForDefaultDisplay());
+                } else {
+                    captureIntent = mediaProjectionManager.createScreenCaptureIntent();
+                }
+
                 // call for the projection manager
-                this.startActivityForResult(
-                        mediaProjectionManager.createScreenCaptureIntent(), requestCode);
+                this.startActivityForResult(captureIntent, requestCode);
             }
         }
 

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -840,7 +840,9 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         result.success(null);
         break;
       case "requestCapturePermission": {
-        getUserMediaImpl.requestCapturePermission(result);
+        Boolean fullScreenOnlyArg = call.argument("fullScreenOnly");
+        boolean fullScreenOnly = fullScreenOnlyArg != null && fullScreenOnlyArg;
+        getUserMediaImpl.requestCapturePermission(result, fullScreenOnly);
         break;
       }
       case "getDisplayMedia": {

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -183,10 +183,21 @@ class Helper {
           AppleNativeAudioManagement.getAppleAudioConfigurationForMode(mode,
               preferSpeakerOutput: preferSpeakerOutput));
 
-  /// Request capture permission for Android/macOS
-  static Future<bool> requestCapturePermission() async {
+  /// Request capture permission for Android/macOS.
+  ///
+  /// When [fullScreenOnly] is true and running on Android 14+ (API 34), the
+  /// MediaProjection consent dialog only offers entire-screen capture and the
+  /// single-app option is removed (via
+  /// `MediaProjectionConfig.createConfigForDefaultDisplay()`). Has no effect on
+  /// older Android versions or on macOS. Defaults to false, which keeps the
+  /// platform's default user-choice dialog.
+  static Future<bool> requestCapturePermission(
+      {bool fullScreenOnly = false}) async {
     if (WebRTC.platformIsAndroid || WebRTC.platformIsMacOS) {
-      return await WebRTC.invokeMethod('requestCapturePermission');
+      return await WebRTC.invokeMethod(
+        'requestCapturePermission',
+        <String, dynamic>{'fullScreenOnly': fullScreenOnly},
+      );
     } else {
       throw Exception(
           'requestCapturePermission only support for Android/macOS');


### PR DESCRIPTION
Resolves #2080

## Summary

On Android 14 (API 34+), the `MediaProjection` consent dialog lets the user choose between sharing a **single app** or the **entire screen**. Some apps (remote support, screen mirroring) only support full-screen capture and the single-app option is confusing/unusable for them.

This adds an opt-in `fullScreenOnly` flag to `Helper.requestCapturePermission()`. When `true` and running on API 34+, the screen-capture intent is created with `MediaProjectionConfig.createConfigForDefaultDisplay()`, which forces entire-screen capture and removes the single-app option from the consent dialog.

```dart
// only offer entire-screen capture on Android 14+
await Helper.requestCapturePermission(fullScreenOnly: true);
```

## Details

- **Opt-in, non-breaking**: defaults to `false`, so existing callers and the `getDisplayMedia` path are unchanged.
- **API-gated**: the `MediaProjectionConfig` branch only runs on `Build.VERSION_CODES.UPSIDE_DOWN_CAKE` (API 34) and above; older versions fall back to the existing `createScreenCaptureIntent()`.
- **No effect on macOS**: the flag is threaded only through the Android `MediaProjection` path.
- Flag flows: `helper.dart` → `MethodCallHandlerImpl` (`fullScreenOnly` arg, null-safe) → `GetUserMediaImpl.requestCapturePermission` → `screenRequestPermissions` (a backward-compatible 1-arg overload delegates to `false`) → Fragment args → `requestStart`.

## Testing

Built and verified on an Android 16 (API 36) emulator:
- `fullScreenOnly: true` → consent dialog defaults to "entire screen" and the single-app option is disabled ("not supported by this app").
- `fullScreenOnly: false` (default) → unchanged user-choice dialog.
