### PR TITLE
release: 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,24 @@
 
 [Unreleased]
 
-* [Darwin/Android] Bump WebRTC-SDK to 144.7559.09 (audio processing state v2, webrtc-sdk/webrtc#254).
-* [Windows/Linux] Bump prebuilt libwebrtc to libwebrtc.m144.7559.09.
-* [Android] Support AGP 9's built-in Kotlin: apply the Kotlin Gradle Plugin only when built-in Kotlin is inactive (AGP < 9, or AGP 9 with `android.builtInKotlin=false`), set the JVM target through the `kotlin { compilerOptions {} }` DSL when available, and fall back to the legacy `kotlinOptions` DSL for apps still on Kotlin Gradle Plugin 1.8.x.
-* [Windows/Linux] fix: Map echoCancellation/noiseSuppression/autoGainControl constraints to RTCAudioOptions so software AEC/NS/AGC can actually be toggled from Dart (#XXXX).
+[1.5.0] - 2026-06-12
+
+* [iOS/macOS] feat: enable platform rendering (`RTCVideoPlatFormView`) on macOS, with a shared Darwin implementation (#2058).
+* [iOS/macOS] feat: use the AVAudioEngine audio device module on both platforms, enabling Apple platform voice processing (AEC/NS/AGC) and the audio processing options API on macOS (#2009, #2082).
+* [Windows] feat: loopback capture for application and desktop audio (#2060).
+* [iOS/macOS] feat: allow embedders to own audio session management (#2069).
+* [Android] feat: expose the peer connection factory to embedders (#2077).
+* [Android] chore: support AGP 9 built-in Kotlin; apply KGP only when built-in Kotlin is inactive (#2075).
+* [Windows/Linux] fix: map echoCancellation/noiseSuppression/autoGainControl constraints to RTCAudioOptions (#2068).
+* [Android] fix: screen capture rotation (#2055) and rotation after orientation changes (#2048).
+* [Android] fix: prevent CameraAccessException on concurrent video calls (#2013).
+* [Android] fix: tolerate Qualcomm/Hisi encoders in VideoFileRenderer (#2030) and guard muxer writes against invalid sample buffers (#2031).
+* [Android] fix: IllegalStateException when the app is swipe-killed during a session (#2033).
+* [iOS] fix: audio session output port override for speaker toggle (#1941).
+* [Dart] fix: handling of `KeyDerivationAlgorithm` option (#2049).
+* [Windows/Linux] chore: drive prebuilt libwebrtc download from `third_party/libwebrtc_version.ini` (#2061).
+* [Darwin/Android] chore: bump WebRTC-SDK to 144.7559.09 (#2078).
+* [Windows/Linux] chore: bump prebuilt libwebrtc to m144.7559.09 (#2078).
 
 [1.4.1] -2026-03-24
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_webrtc
 description: Flutter WebRTC plugin for iOS/Android/Desktop/Web, based on GoogleWebRTC.
-version: 1.4.1
+version: 1.5.0
 homepage: https://github.com/cloudwebrtc/flutter-webrtc
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Rolls up everything since 1.4.1 — see CHANGELOG for the full list. Highlights:

- macOS platform rendering (#2058) and iOS AVAudioEngine ADM (#2009)
- WebRTC-SDK 144.7559.09 / libwebrtc.m144.7559.09 across all platforms (#2078)
- AGP 9 built-in Kotlin support (#2075)
- Android factory accessor for embedders (#2077)
- Windows loopback capture (#2060)

After merge: tag and `flutter pub publish` per the usual flow.