### PR TITLE
macos: use the AVAudioEngine audio device module

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -331,22 +331,19 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
         VideoEncoderFactorySimulcast* simulcastFactory =
             [[VideoEncoderFactorySimulcast alloc] initWithPrimary:encoderFactory fallback:encoderFactory];
 
-        // macOS Screen Share Audio Crash Fix:
-        // Use CoreAudio ADM (value 0) instead of AVAudioEngine (RTCAudioDeviceModuleTypeAudioEngine)
-        // AVAudioEngine crashes when screen share audio and microphone coexist due to
-        // format conflicts in AVAudioIONodeImpl::SetOutputFormat
-        // See: https://github.com/flutter-webrtc/flutter-webrtc/issues/1986
+        // Use the AVAudioEngine audio device module on both iOS and macOS.
         //
-        // Initializing the Audio Device Module Type with 0 leads to a crash on iOS
-        // in case NSMicrophoneUsageDescription is missing in Info.plist file
-        // (consumer/viewer only stream without microphone)
-        // this condition uses AVAudioEngine for iOS while preserving the fix above for macOS
-        // See: https://github.com/flutter-webrtc/flutter-webrtc/issues/2007
-#if TARGET_OS_IPHONE
+        // macOS previously used the CoreAudio ADM (value 0) to avoid an
+        // AVAudioIONodeImpl::SetOutputFormat sample-rate assertion when the
+        // microphone toggled during screen share (#1986, #1990). That crash
+        // predates the audio engine stability fixes shipped in WebRTC-SDK
+        // 144.7559.04+ (webrtc-sdk/webrtc#228: guarded connect:to:format:,
+        // state-based voice-processing checks, engine recreate ordering).
+        // The AudioEngine ADM enables platform voice processing (Apple
+        // AEC/NS/AGC) and the audio processing options API on macOS.
+        // iOS also requires the AudioEngine ADM because the CoreAudio ADM
+        // crashes when NSMicrophoneUsageDescription is absent (#2007, #2009).
         RTCAudioDeviceModuleType audioDeviceModuleType = RTCAudioDeviceModuleTypeAudioEngine;
-#else
-        RTCAudioDeviceModuleType audioDeviceModuleType = 0;
-#endif
         _peerConnectionFactory =
             [[RTCPeerConnectionFactory alloc] initWithAudioDeviceModuleType:audioDeviceModuleType
                                                       bypassVoiceProcessing:bypassVoiceProcessing


### PR DESCRIPTION
## What

Switches the macOS audio device module from CoreAudio (`audioDeviceModuleType` 0) to AVAudioEngine (`RTCAudioDeviceModuleTypeAudioEngine`), matching iOS.

## Why the CoreAudio fallback existed

macOS moved to CoreAudio in #1990 to avoid an `AVAudioIONodeImpl::SetOutputFormat` sample-rate assertion that fired when the microphone toggled during screen share (#1986, #1990):

```
required condition is false: format.sampleRate == hwFormat.sampleRate
```

## Why it's safe to revert now

That crash predates the audio engine stability work in WebRTC-SDK **144.7559.04+** — specifically webrtc-sdk/webrtc#228, which added `@try/@catch` guards around all `connect:to:format:` calls (the `IsFormatSampleRateAndChannelCountValid` crashes), replaced hardware voice-processing property reads with state-based checks (an `EXC_BAD_ACCESS` source), and fixed engine recreate / buffer-stop ordering.

Verified locally on **144.7559.09**: with an active ScreenCaptureKit session, toggling the microphone on/off repeatedly and switching input devices produced no `SetOutputFormat` assertion and no crash report (previously a reliable repro).

## Payoff

Brings macOS to parity with iOS: enables Apple platform voice processing (AEC/NS/AGC) and the audio processing options API on macOS, instead of software-only APM.

## Note

Requires WebRTC-SDK 144.7559.04+ (this repo is on .09). Draft pending broader hardware validation — macOS audio hardware varies, and the original crash was sample-rate-mismatch driven (e.g. 24kHz↔48kHz on Bluetooth headset transitions).