### PR TITLE
fix: stop gitignoring checked-in third_party source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,8 @@ migrate_working_dir/
 .flutter-plugins
 .flutter-plugins-dependencies
 build/
-third_party/
+# Prebuilt libwebrtc artifacts fetched at configure time (see
+# third_party/CMakeLists.txt). The checked-in source under third_party/
+# (CMakeLists.txt, libwebrtc_version.ini, svpng/) is published with the package.
+third_party/downloads/
+third_party/libwebrtc/


### PR DESCRIPTION
## Problem

The `v1.5.0` publish to pub.dev failed (exit 65):

```
Package validation found the following potential issue:
* 4 checked-in files are ignored by a `.gitignore`.
  third_party/CMakeLists.txt
  third_party/libwebrtc_version.ini
  third_party/svpng/LICENSE
  third_party/svpng/svpng.hpp
```

The root `.gitignore` had a blanket `third_party/`, but those four files are checked in (and needed at build time — the Windows/Linux CMake reads `libwebrtc_version.ini`). `dart pub publish` treats checked-in-but-gitignored files as a warning and fails the automated publish. The collision surfaced now because #2061 added `third_party/CMakeLists.txt` + `libwebrtc_version.ini`.

## Fix

Narrow the ignore to the build-time artifact directories (`third_party/downloads/`, `third_party/libwebrtc/`) that the CMake fetch creates, leaving the checked-in source clean. Verified the three source paths are no longer matched while the two artifact dirs still are.

Nothing was published for 1.5.0 (validation fails before upload), so 1.5.0 can be re-published once this lands.