### PR TITLE
chore(android): bump audioswitch to 039a35ae

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 [Unreleased]
 
+* [Android] chore: bump audioswitch to 039a35ae, aligning with the LiveKit Android SDK (Communication Device API support, wired headset and Bluetooth fixes).
 [1.5.0] - 2026-06-12
 
 * [iOS/macOS] feat: enable platform rendering (`RTCVideoPlatFormView`) on macOS, with a shared Darwin implementation (#2058).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,6 @@ if (kotlinExt?.hasProperty('compilerOptions')) {
 
 dependencies {
     implementation 'io.github.webrtc-sdk:android:144.7559.09'
-    implementation 'com.github.davidliu:audioswitch:89582c47c9a04c62f90aa5e57251af4800a62c9a'
+    implementation 'com.github.davidliu:audioswitch:039a35aefab7747c557242fa216c9ea11743b604'
     implementation 'androidx.annotation:annotation:1.1.0'
 }


### PR DESCRIPTION
## What

Bumps `com.github.davidliu:audioswitch` from `89582c47` to `039a35ae` — the revision pinned by the [LiveKit Android SDK](https://github.com/livekit/client-sdk-android/blob/main/gradle/libs.versions.toml).

## What the 4 commits in between bring

- `CommDeviceAudioSwitch` (davidliu/audioswitch#7): routing via the Android 12+ Communication Device API (`setCommunicationDevice`), replacing the deprecated `setSpeakerphoneOn`/`startBluetoothSco` path on modern devices
- Fix: selected audio device not updating when a wired headset is plugged in (davidliu/audioswitch#6)
- `CommDeviceAudioSwitch` matched to previous earpiece/wired behavior (davidliu/audioswitch#8)
- Crash guard when unregistering communication device listeners (davidliu/audioswitch#9)

## Why now

Gradle resolves a single audioswitch revision per app classpath, and SHA-pinned JitPack versions compare string-wise — so an app combining flutter_webrtc with another plugin pinning `039a35ae` (e.g. the LiveKit Flutter SDK) can end up with whichever string sorts higher, losing classes the newer revision provides. Aligning everyone on the same revision removes the ambiguity.

flutter_webrtc itself only uses `AudioSwitch` and `AudioDevice`, both unchanged across this range — no code changes needed.