### PR TITLE
fix(android): recreate texture surface when frame size changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 [Unreleased]
 
 * [Android] chore: bump audioswitch to 039a35ae, aligning with the LiveKit Android SDK (Communication Device API support, wired headset and Bluetooth fixes).
+* [Android] fix: recreate the texture surface when the incoming frame size changes, so simulcast layer upgrades no longer stay blurry.
+
 [1.5.0] - 2026-06-12
 
 * [iOS/macOS] feat: enable platform rendering (`RTCVideoPlatFormView`) on macOS, with a shared Darwin implementation (#2058).

--- a/android/src/main/java/com/cloudwebrtc/webrtc/SurfaceTextureRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/SurfaceTextureRenderer.java
@@ -102,9 +102,26 @@ public class SurfaceTextureRenderer extends EglRenderer {
       producer.setSize(frame.getRotatedWidth(),frame.getRotatedHeight());
       surface = producer.getSurface();
       createEglSurface(surface);
+    } else if (frameSizeChanged(frame)) {
+      // The producer's backing buffers are fixed-size: setSize() only takes
+      // effect for a Surface obtained afterwards. Without recreating the EGL
+      // surface here, a simulcast layer upgrade keeps rendering into the old
+      // low-resolution buffer and the video stays blurry.
+      releaseEglSurface(() -> {});
+      producer.setSize(frame.getRotatedWidth(), frame.getRotatedHeight());
+      surface = producer.getSurface();
+      createEglSurface(surface);
     }
     updateFrameDimensionsAndReportEvents(frame);
     super.onFrame(frame);
+  }
+
+  private boolean frameSizeChanged(VideoFrame frame) {
+    synchronized (layoutLock) {
+      return !isRenderingPaused
+          && (rotatedFrameWidth != frame.getRotatedWidth()
+              || rotatedFrameHeight != frame.getRotatedHeight());
+    }
   }
 
   private Surface surface = null;
@@ -158,7 +175,6 @@ public class SurfaceTextureRenderer extends EglRenderer {
         }
         rotatedFrameWidth = frame.getRotatedWidth();
         rotatedFrameHeight = frame.getRotatedHeight();
-        producer.setSize(rotatedFrameWidth, rotatedFrameHeight);
         frameRotation = frame.getRotation();
       }
     }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/SurfaceTextureRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/SurfaceTextureRenderer.java
@@ -98,19 +98,25 @@ public class SurfaceTextureRenderer extends EglRenderer {
   // VideoSink interface.
   @Override
   public void onFrame(VideoFrame frame) {
-    if(surface == null) {
-      producer.setSize(frame.getRotatedWidth(),frame.getRotatedHeight());
-      surface = producer.getSurface();
-      createEglSurface(surface);
-    } else if (frameSizeChanged(frame)) {
-      // The producer's backing buffers are fixed-size: setSize() only takes
-      // effect for a Surface obtained afterwards. Without recreating the EGL
-      // surface here, a simulcast layer upgrade keeps rendering into the old
-      // low-resolution buffer and the video stays blurry.
-      releaseEglSurface(() -> {});
-      producer.setSize(frame.getRotatedWidth(), frame.getRotatedHeight());
-      surface = producer.getSurface();
-      createEglSurface(surface);
+    synchronized (surfaceLock) {
+      if(surface == null) {
+        producer.setSize(frame.getRotatedWidth(),frame.getRotatedHeight());
+        surface = producer.getSurface();
+        createEglSurface(surface);
+      } else if (frameSizeChanged(frame)) {
+        // The producer's backing buffers are fixed-size: setSize() only takes
+        // effect for a Surface obtained afterwards. Without recreating the EGL
+        // surface here, a simulcast layer upgrade keeps rendering into the old
+        // low-resolution buffer and the video stays blurry.
+        releaseEglSurface(() -> {});
+        // Clear the field before re-obtaining: if getSurface() throws, the
+        // next frame takes the surface == null path and recreates cleanly
+        // rather than rendering into the already-released surface.
+        surface = null;
+        producer.setSize(frame.getRotatedWidth(), frame.getRotatedHeight());
+        surface = producer.getSurface();
+        createEglSurface(surface);
+      }
     }
     updateFrameDimensionsAndReportEvents(frame);
     super.onFrame(frame);
@@ -124,6 +130,14 @@ public class SurfaceTextureRenderer extends EglRenderer {
     }
   }
 
+  // Guards surface lifecycle transitions: creation/recreation happens on the
+  // frame delivery thread while destruction arrives on the main thread via
+  // the producer's onSurfaceCleanup callback. Serializing the two prevents a
+  // frame from re-creating the EGL surface against a Surface the producer is
+  // concurrently invalidating. surfaceDestroyed() blocks on the EGL release
+  // while holding this lock; the latch is signaled by the EglRenderer render
+  // thread, which never acquires it, so the wait cannot deadlock.
+  private final Object surfaceLock = new Object();
   private Surface surface = null;
 
   private TextureRegistry.SurfaceProducer producer;
@@ -148,10 +162,12 @@ public class SurfaceTextureRenderer extends EglRenderer {
 
   public void surfaceDestroyed() {
     ThreadUtils.checkIsOnMainThread();
-    final CountDownLatch completionLatch = new CountDownLatch(1);
-    releaseEglSurface(completionLatch::countDown);
-    ThreadUtils.awaitUninterruptibly(completionLatch);
-    surface = null;
+    synchronized (surfaceLock) {
+      final CountDownLatch completionLatch = new CountDownLatch(1);
+      releaseEglSurface(completionLatch::countDown);
+      ThreadUtils.awaitUninterruptibly(completionLatch);
+      surface = null;
+    }
   }
 
   // Update frame dimensions and report any changes to |rendererEvents|.


### PR DESCRIPTION
## Problem

On Android, when a subscribed video upgrades to a higher simulcast layer, the rendered video stays blurry even once 720p frames arrive. Repro: subscribe while the publisher starts on a low layer → renderer initializes at the low resolution → layer upgrades → still blurry.

## Cause

`SurfaceTextureRenderer.onFrame` creates the EGL surface once, sized by the **first** frame. On a later resolution change, `updateFrameDimensionsAndReportEvents` called `producer.setSize()` — but `TextureRegistry.SurfaceProducer`'s backing buffers are fixed-size, and `setSize()` only takes effect for a Surface obtained **afterwards** via `getSurface()` (the ImageReader-backed producer from the #1726 Surface API migration). The renderer kept GL-downscaling upgraded frames into the original low-resolution buffer, which Flutter then upscaled for display: permanently blurry.

iOS is unaffected — its renderer delivers per-frame pixel buffers with no fixed-size backing, matching the Android-only reports.

## Fix

When the rotated frame dimensions change, release the EGL surface, `setSize()`, re-obtain the producer surface, and recreate the EGL surface — the same sequence as first-frame creation. The size-change check reuses the existing `layoutLock` dimension tracking; rotation-only changes (which don't alter rotated dimensions) don't trigger recreation. The now-redundant `setSize()` in `updateFrameDimensionsAndReportEvents` is removed so surface sizing has a single owner.

## Testing

- Compiles (example apk).
- Needs runtime verification with a simulcast publisher and a subscriber starting on a low layer (dynacast or constrained bandwidth), watching the upgrade un-blur. Reported and reproduced by LiveKit (Android-only).