### PR TITLE
fix(ios/macos): set AVAssetWriter transform from frame rotation (portrait recordings saved sideways)

### DIFF
--- a/common/darwin/Classes/FlutterRTCMediaRecorder.m
+++ b/common/darwin/Classes/FlutterRTCMediaRecorder.m
@@ -5,6 +5,21 @@
 
 @import AVFoundation;
 
+// Map the capture rotation — already carried by every RTCVideoFrame, the same
+// RTCVideoRotation the live RTP path consumes — to the AVAssetWriterInput
+// display transform, so portrait recordings are written upright instead of
+// sideways. Reads the real per-frame value (front/back cameras report 90 vs
+// 270), so it is correct for selfie and rear recording alike.
+static CGAffineTransform RTCVideoRotationToCGAffineTransform(RTCVideoRotation rotation) {
+    switch (rotation) {
+        case RTCVideoRotation_90:  return CGAffineTransformMakeRotation(M_PI_2);
+        case RTCVideoRotation_180: return CGAffineTransformMakeRotation(M_PI);
+        case RTCVideoRotation_270: return CGAffineTransformMakeRotation(-M_PI_2);
+        case RTCVideoRotation_0:
+        default:                   return CGAffineTransformIdentity;
+    }
+}
+
 @implementation FlutterRTCMediaRecorder {
     int framesCount;
     bool isInitialized;
@@ -29,7 +44,7 @@
     return self;
 }
 
-- (void)initialize:(CGSize)size {
+- (void)initialize:(CGSize)size rotation:(RTCVideoRotation)rotation {
     _renderSize = size;
     NSDictionary *videoSettings = @{
         AVVideoCompressionPropertiesKey: @{AVVideoAverageBitRateKey: @(6*1024*1024)},
@@ -42,6 +57,11 @@
                outputSettings:videoSettings];
     self.writerInput.expectsMediaDataInRealTime = true;
     self.writerInput.mediaTimeScale = 30;
+    // Keep the raw buffer dimensions and express orientation via the display
+    // transform (the Apple-native pattern); do NOT also swap width/height or it
+    // would double-rotate. Set once, before -startWriting, from the first
+    // frame's rotation.
+    self.writerInput.transform = RTCVideoRotationToCGAffineTransform(rotation);
 
     if (_audioSink != nil) {
         AudioChannelLayout acl;
@@ -95,7 +115,7 @@
         return;
     }
     if (!isInitialized) {
-        [self initialize:CGSizeMake((CGFloat) frame.width, (CGFloat) frame.height)];
+        [self initialize:CGSizeMake((CGFloat) frame.width, (CGFloat) frame.height) rotation:frame.rotation];
     }
     if (!self.writerInput.readyForMoreMediaData) {
         NSLog(@"Drop frame, not ready");


### PR DESCRIPTION
## Problem
On iOS/macOS, `MediaRecorder` saves **portrait recordings sideways**. The recorded `.mp4` has the raw landscape capture buffer with no rotation, so every player shows it rotated 90°.

## Root cause
`FlutterRTCMediaRecorder` (`common/darwin/Classes/FlutterRTCMediaRecorder.m`) initializes the `AVAssetWriterInput` from the raw `frame.width × frame.height` and **never sets `writerInput.transform` from the frame's rotation** — even though every `RTCVideoFrame` already carries the correct `RTCVideoRotation` (the same value the RTP/live path consumes).

The platform asymmetry confirms it: the **Android** recorder already handles this — `VideoFileRenderer` sizes the encoder via `getRotatedWidth()/getRotatedHeight()` and draws through `VideoFrameDrawer`, which honors `frame.getRotation()`. Same frames, same rotation; Android bakes it, Apple drops it.

## Fix
Set the `AVAssetWriterInput.transform` **once**, from the **first frame's** `frame.rotation`, before `-startWriting`. Keep the raw buffer dimensions and express orientation purely via the display transform — the Apple-native "landscape buffer + `preferredTransform`" pattern. (Swapping the writer dimensions *and* setting a transform would double-rotate.)

Reads the actual per-frame value, so it's correct for both front (`RTCVideoRotation_270`) and rear (`_90`) cameras. Pairs naturally with a portrait-locked capture UI so the set-once transform can't drift mid-clip.

## Verification
- Source-level: the recorder had zero references to `frame.rotation`/`transform`; Android's equivalent does.
- Device: `ffprobe` before/after (no `displaymatrix` → `displaymatrix` present) + visual upright confirmation — **being captured now; I'll attach and mark ready for review.**

(Marked draft until the on-device before/after is attached.)
