### PR TITLE
v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 
 [Unreleased]
 
-* [Android] chore: bump audioswitch to 039a35ae, aligning with the LiveKit Android SDK (Communication Device API support, wired headset and Bluetooth fixes).
-* [Android] fix: recreate the texture surface when the incoming frame size changes, so simulcast layer upgrades no longer stay blurry.
+[1.5.1] - 2026-06-14
+
+* [Android] fix: recreate the texture surface when the incoming frame size changes, so simulcast layer upgrades no longer stay blurry (#2085).
+* [Android] chore: bump audioswitch to 039a35ae, aligning with the LiveKit Android SDK (Communication Device API support, wired headset and Bluetooth fixes) (#2084).
+* [Android] feat: add `fullScreenOnly` option to `requestCapturePermission` to force entire-screen capture on API 34+ (#2079).
+* [Darwin] fix: call `SetRecordingDevice(0)` when no sourceId is supplied (#2072).
 
 [1.5.0] - 2026-06-12
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_webrtc
 description: Flutter WebRTC plugin for iOS/Android/Desktop/Web, based on GoogleWebRTC.
-version: 1.5.0
+version: 1.5.1
 homepage: https://github.com/cloudwebrtc/flutter-webrtc
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Patch release rolling up the four changes since `v1.5.0`.

## Changes

- **[Android] fix:** recreate the texture surface when the incoming frame size changes, so simulcast layer upgrades no longer stay blurry (#2085).
- **[Android] chore:** bump audioswitch to `039a35ae`, aligning with the LiveKit Android SDK — Communication Device API support plus wired-headset and Bluetooth fixes (#2084).
- **[Android] feat:** add `fullScreenOnly` option to `requestCapturePermission` to force entire-screen capture on API 34+ (#2079).
- **[Darwin] fix:** call `SetRecordingDevice(0)` when no sourceId is supplied (#2072).

## Notes

- Patch bump: all fixes plus one additive option, no breaking changes.
- `pubspec.yaml` 1.5.0 → 1.5.1; CHANGELOG dated section added.
- After merge: create the `v1.5.1` GitHub release on the merge commit; the `v*` tag triggers the publish workflow → pub.dev.
