### PR TITLE
fix(macos): create parent directory before captureFrame writes the file

### DIFF
--- a/common/darwin/Classes/FlutterRTCFrameCapturer.m
+++ b/common/darwin/Classes/FlutterRTCFrameCapturer.m
@@ -93,11 +93,26 @@
   CGImageRelease(cgImage);
   if (shouldRelease)
     CVPixelBufferRelease(pixelBufferRef);
+
+  // Ensure the parent directory exists before writing the file
+  NSString* parentDir = [_path stringByDeletingLastPathComponent];
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+  if (![fileManager fileExistsAtPath:parentDir]) {
+    NSError* dirError = nil;
+    [fileManager createDirectoryAtPath:parentDir
+           withIntermediateDirectories:YES
+                            attributes:nil
+                                 error:&dirError];
+    if (dirError) {
+      NSLog(@"[CaptureFrame] Failed to create directory: %@, error: %@", parentDir, dirError);
+    }
+  }
+
   if (imageData && [imageData writeToFile:_path atomically:NO]) {
-    NSLog(@"File writed successfully to %@", _path);
     _result(nil);
   } else {
-    NSLog(@"Failed to write to file");
+    NSLog(@"[CaptureFrame] Failed to write file - imageData=%@, path=%@",
+          imageData ? @"not nil" : @"nil", _path);
     _result([FlutterError errorWithCode:@"CaptureFrameFailed"
                                 message:@"Failed to write image data to file"
                                 details:nil]);


### PR DESCRIPTION
### What

`FlutterRTCFrameCapturer` (shared by iOS/macOS) writes the captured frame with `[imageData writeToFile:_path atomically:NO]`. When the parent directory of `_path` does not exist the write fails with only a generic `Failed to write to file` log.

This change creates the intermediate directories with `NSFileManager` before the write, and makes the failure path actionable by returning a `FlutterError` and logging whether `imageData` was nil plus the target path.

### Why

Closes #2089. Callers that pass a not-yet-created subdirectory currently get an opaque failure; creating the directory first matches the expectation that `captureFrame(path)` works for a fresh path.

### Changes

- `common/darwin/Classes/FlutterRTCFrameCapturer.m`: create parent directory before writing; clearer error/log on failure.

### Notes

- Single file, no public API change.
- Original change authored by 송건호 <ghsong@rsupport.com>; submitted via fork.