### PR TITLE
feat: custom video source — publish app-registered/composited frames as a video track

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,8 @@ if (kotlinExt?.hasProperty('compilerOptions')) {
 }
 
 dependencies {
-    implementation 'io.github.webrtc-sdk:android:144.7559.09'
+    // custom video source API (CustomVideoCapturer) exposes org.webrtc types, so expose webrtc-sdk transitively via `api`
+    api 'io.github.webrtc-sdk:android:144.7559.09'
     implementation 'com.github.davidliu:audioswitch:039a35aefab7747c557242fa216c9ea11743b604'
     implementation 'androidx.annotation:annotation:1.1.0'
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/GetUserMediaImpl.java
@@ -50,6 +50,9 @@ import com.cloudwebrtc.webrtc.utils.ObjectType;
 import com.cloudwebrtc.webrtc.utils.PermissionUtils;
 import com.cloudwebrtc.webrtc.video.LocalVideoTrack;
 import com.cloudwebrtc.webrtc.video.VideoCapturerInfo;
+import com.cloudwebrtc.webrtc.video.custom.CustomVideoCapturer;
+import com.cloudwebrtc.webrtc.video.custom.CustomVideoCapturerFactory;
+import com.cloudwebrtc.webrtc.video.custom.CustomVideoSourceRegistry;
 
 import org.webrtc.AudioSource;
 import org.webrtc.AudioTrack;
@@ -80,6 +83,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.flutter.plugin.common.MethodChannel.Result;
 
@@ -107,6 +111,7 @@ public class GetUserMediaImpl {
 
     private final Map<String, VideoCapturerInfoEx> mVideoCapturers = new HashMap<>();
     private final Map<String, SurfaceTextureHelper> mSurfaceTextureHelpers = new HashMap<>();
+    private final Map<String, CustomVideoCapturer> mCustomVideoCapturers = new ConcurrentHashMap<>();
     private final StateProvider stateProvider;
     private final Context applicationContext;
 
@@ -617,6 +622,138 @@ public class GetUserMediaImpl {
     }
 
     /**
+     * Creates a local video track fed by an application-registered {@link CustomVideoCapturer}
+     * (see {@link CustomVideoSourceRegistry}), following the same pipeline as the camera path.
+     */
+    void createCustomVideoTrack(ConstraintsMap constraintsMap, Result result) {
+        String sourceType = constraintsMap.getString("sourceType");
+        if (sourceType == null) {
+            resultError("createCustomVideoTrack", "sourceType is required", result);
+            return;
+        }
+
+        CustomVideoCapturerFactory factory = CustomVideoSourceRegistry.get(sourceType);
+        if (factory == null) {
+            result.error(
+                    "CustomVideoSourceNotRegistered",
+                    "createCustomVideoTrack(): no factory registered for sourceType: " + sourceType,
+                    null);
+            return;
+        }
+
+        int width = constraintsMap.hasKey("width") ? constraintsMap.getInt("width") : DEFAULT_WIDTH;
+        int height = constraintsMap.hasKey("height") ? constraintsMap.getInt("height") : DEFAULT_HEIGHT;
+        int fps = constraintsMap.hasKey("fps") ? constraintsMap.getInt("fps") : DEFAULT_FPS;
+        Map<String, Object> options =
+                constraintsMap.getType("options") == ObjectType.Map
+                        ? constraintsMap.getMap("options").toMap()
+                        : new HashMap<>();
+
+        CustomVideoCapturer videoCapturer = factory.create(applicationContext, options);
+        if (videoCapturer == null) {
+            resultError("createCustomVideoTrack",
+                    "factory returned null capturer for sourceType: " + sourceType, result);
+            return;
+        }
+
+        PeerConnectionFactory pcFactory = stateProvider.getPeerConnectionFactory();
+        String streamId = stateProvider.getNextStreamUUID();
+        MediaStream mediaStream = pcFactory.createLocalMediaStream(streamId);
+        if (mediaStream == null) {
+            resultError("createCustomVideoTrack", "Failed to create new media stream", result);
+            return;
+        }
+
+        VideoSource videoSource = pcFactory.createVideoSource(false);
+        String threadName = Thread.currentThread().getName() + "_texture_custom_thread";
+        SurfaceTextureHelper surfaceTextureHelper =
+                SurfaceTextureHelper.create(threadName, EglUtils.getRootEglBaseContext());
+
+        if (surfaceTextureHelper == null) {
+            resultError("createCustomVideoTrack", "surfaceTextureHelper is null", result);
+            return;
+        }
+
+        videoCapturer.initialize(
+                surfaceTextureHelper, applicationContext, videoSource.getCapturerObserver());
+
+        VideoCapturerInfoEx info = new VideoCapturerInfoEx();
+        info.width = width;
+        info.height = height;
+        info.fps = fps;
+        info.capturer = videoCapturer;
+
+        videoCapturer.startCapture(width, height, fps);
+        Log.d(TAG, "CustomVideoCapturer(" + sourceType + ").startCapture: " + width + "x" + height + "@" + fps);
+
+        String trackId = stateProvider.getNextTrackUUID();
+        mVideoCapturers.put(trackId, info);
+        mSurfaceTextureHelpers.put(trackId, surfaceTextureHelper);
+        mCustomVideoCapturers.put(trackId, videoCapturer);
+
+        VideoTrack track = pcFactory.createVideoTrack(trackId, videoSource);
+        mediaStream.addTrack(track);
+
+        LocalVideoTrack localVideoTrack = new LocalVideoTrack(track);
+        videoSource.setVideoProcessor(localVideoTrack);
+
+        stateProvider.putLocalTrack(track.id(), localVideoTrack);
+
+        ConstraintsMap trackParams = new ConstraintsMap();
+        trackParams.putBoolean("enabled", track.enabled());
+        trackParams.putString("id", track.id());
+        trackParams.putString("kind", "video");
+        trackParams.putString("label", track.id());
+        trackParams.putString("readyState", track.state().toString());
+        trackParams.putBoolean("remote", false);
+
+        ConstraintsMap settings = new ConstraintsMap();
+        settings.putString("deviceId", sourceType);
+        settings.putString("kind", "videoinput");
+        settings.putInt("width", width);
+        settings.putInt("height", height);
+        settings.putInt("frameRate", fps);
+        trackParams.putMap("settings", settings.toMap());
+
+        Log.d(TAG, "MediaStream id: " + streamId);
+        stateProvider.putLocalStream(streamId, mediaStream);
+
+        ConstraintsArray audioTracks = new ConstraintsArray();
+        ConstraintsArray videoTracks = new ConstraintsArray();
+        videoTracks.pushMap(trackParams);
+
+        ConstraintsMap successResult = new ConstraintsMap();
+        successResult.putString("streamId", streamId);
+        successResult.putArray("audioTracks", audioTracks.toArrayList());
+        successResult.putArray("videoTracks", videoTracks.toArrayList());
+        result.success(successResult.toMap());
+    }
+
+    void customVideoSourceCommand(
+            String trackId, String command, @Nullable Map<String, Object> args, Result result) {
+        CustomVideoCapturer capturer = mCustomVideoCapturers.get(trackId);
+        if (capturer == null) {
+            result.error(
+                    "CustomVideoSourceUnknownTrack",
+                    "customVideoSourceCommand(): no custom video capturer for trackId: " + trackId,
+                    null);
+            return;
+        }
+        try {
+            // Runs on the method-channel caller thread; off-loading heavy work
+            // is the capturer implementation's responsibility.
+            result.success(capturer.handleCommand(command, args));
+        } catch (UnsupportedOperationException e) {
+            result.error(
+                    "CustomVideoSourceCommandUnsupported",
+                    "customVideoSourceCommand(): unsupported command: " + command,
+                    null);
+        } catch (Exception e) {
+            resultError("customVideoSourceCommand", e.getMessage(), result);
+        }
+    }
+
+    /**
      * Implements {@code getUserMedia} with the knowledge that the necessary permissions have already
      * been granted. If the necessary permissions have not been granted yet, they will NOT be
      * requested.
@@ -998,6 +1135,7 @@ public class GetUserMediaImpl {
             } finally {
                 info.capturer.dispose();
                 mVideoCapturers.remove(id);
+                mCustomVideoCapturers.remove(id);
                 SurfaceTextureHelper helper = mSurfaceTextureHelpers.get(id);
                 if (helper != null) {
                     helper.stopListening();

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -1150,6 +1150,19 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         //Log.d(TAG, "no implementation for 'setLogSeverity'");
         break;
       }
+      case "createCustomVideoTrack": {
+        Map<String, Object> arguments = call.arguments();
+        ConstraintsMap constraintsMap = new ConstraintsMap(arguments);
+        getUserMediaImpl.createCustomVideoTrack(constraintsMap, result);
+        break;
+      }
+      case "customVideoSourceCommand": {
+        String trackId = call.argument("trackId");
+        String command = call.argument("command");
+        Map<String, Object> args = call.argument("args");
+        getUserMediaImpl.customVideoSourceCommand(trackId, command, args, result);
+        break;
+      }
       default:
         if(frameCryptor.handleMethodCall(call, result)) {
           break;

--- a/android/src/main/java/com/cloudwebrtc/webrtc/video/custom/CustomVideoCapturer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/video/custom/CustomVideoCapturer.java
@@ -1,0 +1,26 @@
+package com.cloudwebrtc.webrtc.video.custom;
+
+import androidx.annotation.Nullable;
+
+import org.webrtc.VideoCapturer;
+
+import java.util.Map;
+
+/**
+ * A {@link VideoCapturer} supplied by the application to feed externally
+ * composited frames (e.g. ARCore camera + overlay) into a local video track.
+ * Render into the SurfaceTexture of the SurfaceTextureHelper received in
+ * {@link VideoCapturer#initialize} for zero-copy OES texture frames.
+ */
+public interface CustomVideoCapturer extends VideoCapturer {
+    /**
+     * Handles an application-defined command routed from Dart via the
+     * "customVideoSourceCommand" method channel call. Invoked directly on the
+     * method-channel caller thread; off-loading heavy work is the
+     * implementer's responsibility.
+     *
+     * @throws UnsupportedOperationException if the command is not supported.
+     */
+    @Nullable
+    Object handleCommand(String command, Map<String, Object> args) throws Exception;
+}

--- a/android/src/main/java/com/cloudwebrtc/webrtc/video/custom/CustomVideoCapturerFactory.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/video/custom/CustomVideoCapturerFactory.java
@@ -1,0 +1,13 @@
+package com.cloudwebrtc.webrtc.video.custom;
+
+import android.content.Context;
+
+import java.util.Map;
+
+/**
+ * Creates a {@link CustomVideoCapturer} for a registered source type.
+ * {@code options} is the (possibly empty) map passed from Dart as-is.
+ */
+public interface CustomVideoCapturerFactory {
+    CustomVideoCapturer create(Context appContext, Map<String, Object> options);
+}

--- a/android/src/main/java/com/cloudwebrtc/webrtc/video/custom/CustomVideoSourceRegistry.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/video/custom/CustomVideoSourceRegistry.java
@@ -1,0 +1,28 @@
+package com.cloudwebrtc.webrtc.video.custom;
+
+import androidx.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Process-wide registry mapping a source type name to the factory that
+ * creates its {@link CustomVideoCapturer}. The application registers its
+ * factories (e.g. in Application.onCreate) before Dart calls
+ * "createCustomVideoTrack".
+ */
+public final class CustomVideoSourceRegistry {
+    private static final Map<String, CustomVideoCapturerFactory> factories =
+            new ConcurrentHashMap<>();
+
+    private CustomVideoSourceRegistry() {}
+
+    public static void register(String sourceType, CustomVideoCapturerFactory factory) {
+        factories.put(sourceType, factory);
+    }
+
+    @Nullable
+    public static CustomVideoCapturerFactory get(String sourceType) {
+        return factories.get(sourceType);
+    }
+}

--- a/common/darwin/Classes/FlutterRTCCustomVideoSource.h
+++ b/common/darwin/Classes/FlutterRTCCustomVideoSource.h
@@ -1,0 +1,56 @@
+#import <Foundation/Foundation.h>
+#import <WebRTC/WebRTC.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Error domain used by FlutterRTCCustomVideoCapturer implementations to report
+/// failures from handleCommand:args:error:.
+FOUNDATION_EXPORT NSString* const FlutterRTCCustomVideoSourceErrorDomain;
+
+/// Error code (in FlutterRTCCustomVideoSourceErrorDomain) a capturer must use when it
+/// does not support the requested command. Mapped to the platform error code
+/// "CustomVideoSourceCommandUnsupported" on the method channel.
+FOUNDATION_EXPORT const NSInteger FlutterRTCCustomVideoSourceErrorUnsupportedCommand;
+
+/// A capturer that produces externally composed video frames (e.g. an
+/// ARKit/ARCore camera + overlay composition) for a custom video track.
+/// Implementations push composed RTCVideoFrame instances (RTCCVPixelBuffer,
+/// rotation=0, timeStampNs) to the frameSink passed to the factory.
+@protocol FlutterRTCCustomVideoCapturer <NSObject>
+
+- (void)startCaptureWithWidth:(int)width height:(int)height fps:(int)fps;
+
+- (void)stopCapture;
+
+/// Handles an app-defined command routed from the "customVideoSourceCommand"
+/// method channel call. Returns an arbitrary plist/codec-safe value (map,
+/// scalar or nil). For unsupported commands set *error to an NSError with
+/// domain FlutterRTCCustomVideoSourceErrorDomain and code
+/// FlutterRTCCustomVideoSourceErrorUnsupportedCommand.
+- (nullable id)handleCommand:(NSString*)command
+                        args:(nullable NSDictionary*)args
+                       error:(NSError**)error;
+
+@end
+
+/// Creates a capturer for a custom video source. frameSink is the delegate
+/// (a VideoProcessingAdapter wired to the RTCVideoSource) the capturer must
+/// push frames into. options is the (optional) options map passed verbatim
+/// from the "createCustomVideoTrack" method channel call.
+typedef id<FlutterRTCCustomVideoCapturer> _Nonnull (^FlutterRTCCustomVideoCapturerFactory)(
+    id<RTCVideoCapturerDelegate> _Nonnull frameSink,
+    NSDictionary* _Nullable options);
+
+/// Process-wide registry mapping sourceType names to capturer factories.
+/// The host app registers factories (typically at startup) and Dart creates
+/// tracks via CustomVideoSource.createStream(sourceType, ...).
+@interface FlutterRTCCustomVideoSourceRegistry : NSObject
+
++ (void)registerFactory:(FlutterRTCCustomVideoCapturerFactory)factory
+          forSourceType:(NSString*)sourceType;
+
++ (nullable FlutterRTCCustomVideoCapturerFactory)factoryForSourceType:(NSString*)sourceType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/common/darwin/Classes/FlutterRTCCustomVideoSource.m
+++ b/common/darwin/Classes/FlutterRTCCustomVideoSource.m
@@ -1,0 +1,38 @@
+#import "FlutterRTCCustomVideoSource.h"
+
+NSString* const FlutterRTCCustomVideoSourceErrorDomain = @"FlutterRTCCustomVideoSourceErrorDomain";
+const NSInteger FlutterRTCCustomVideoSourceErrorUnsupportedCommand = 404;
+
+@implementation FlutterRTCCustomVideoSourceRegistry
+
++ (NSMutableDictionary<NSString*, FlutterRTCCustomVideoCapturerFactory>*)factories {
+  static NSMutableDictionary<NSString*, FlutterRTCCustomVideoCapturerFactory>* factories = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    factories = [NSMutableDictionary new];
+  });
+  return factories;
+}
+
++ (void)registerFactory:(FlutterRTCCustomVideoCapturerFactory)factory
+          forSourceType:(NSString*)sourceType {
+  if (!factory || !sourceType) {
+    return;
+  }
+  NSMutableDictionary<NSString*, FlutterRTCCustomVideoCapturerFactory>* factories = [self factories];
+  @synchronized(factories) {
+    factories[sourceType] = [factory copy];
+  }
+}
+
++ (FlutterRTCCustomVideoCapturerFactory)factoryForSourceType:(NSString*)sourceType {
+  if (!sourceType) {
+    return nil;
+  }
+  NSMutableDictionary<NSString*, FlutterRTCCustomVideoCapturerFactory>* factories = [self factories];
+  @synchronized(factories) {
+    return factories[sourceType];
+  }
+}
+
+@end

--- a/common/darwin/Classes/FlutterRTCMediaStream.h
+++ b/common/darwin/Classes/FlutterRTCMediaStream.h
@@ -9,6 +9,10 @@
 
 - (void)getUserMedia:(nonnull NSDictionary*)constraints result:(nonnull FlutterResult)result;
 
+- (void)createCustomVideoTrack:(nonnull NSDictionary*)args result:(nonnull FlutterResult)result;
+
+- (void)customVideoSourceCommand:(nonnull NSDictionary*)args result:(nonnull FlutterResult)result;
+
 - (void)createLocalMediaStream:(nonnull FlutterResult)result;
 
 - (void)getSources:(nonnull FlutterResult)result;

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -4,6 +4,7 @@
 #import "FlutterRTCFrameCapturer.h"
 #import "FlutterRTCMediaStream.h"
 #import "FlutterRTCPeerConnection.h"
+#import "FlutterRTCCustomVideoSource.h"
 #import "VideoProcessingAdapter.h"
 #import "LocalVideoTrack.h"
 #import "LocalAudioTrack.h"
@@ -234,6 +235,138 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
                                    details:nil]);
       }
       mediaStream:mediaStream];
+}
+
+/**
+ * Creates a video track fed by an app-registered {@link FlutterRTCCustomVideoCapturer}
+ * (see {@link FlutterRTCCustomVideoSourceRegistry}) instead of a camera. The capturer
+ * pushes externally composed frames into a {@link VideoProcessingAdapter}
+ * which forwards them to the {@link RTCVideoSource}. Responds with the same
+ * stream map shape as {@code getUserMedia()}.
+ */
+- (void)createCustomVideoTrack:(NSDictionary*)args result:(FlutterResult)result {
+  NSString* sourceType =
+      [args[@"sourceType"] isKindOfClass:[NSString class]] ? args[@"sourceType"] : nil;
+  FlutterRTCCustomVideoCapturerFactory factory =
+      sourceType != nil ? [FlutterRTCCustomVideoSourceRegistry factoryForSourceType:sourceType] : nil;
+  if (!factory) {
+    result([FlutterError
+        errorWithCode:@"CustomVideoSourceNotRegistered"
+              message:[NSString stringWithFormat:@"Error: no custom video source factory "
+                                                 @"registered for sourceType '%@'!",
+                                                 sourceType]
+              details:nil]);
+    return;
+  }
+
+  int width = [args[@"width"] isKindOfClass:[NSNumber class]] ? [args[@"width"] intValue] : 1280;
+  int height = [args[@"height"] isKindOfClass:[NSNumber class]] ? [args[@"height"] intValue] : 720;
+  int fps = [args[@"fps"] isKindOfClass:[NSNumber class]] ? [args[@"fps"] intValue] : 30;
+  NSDictionary* options =
+      [args[@"options"] isKindOfClass:[NSDictionary class]] ? args[@"options"] : nil;
+
+  RTCVideoSource* videoSource = [self.peerConnectionFactory videoSource];
+  VideoProcessingAdapter* videoProcessingAdapter =
+      [[VideoProcessingAdapter alloc] initWithRTCVideoSource:videoSource];
+
+  id<FlutterRTCCustomVideoCapturer> capturer = factory(videoProcessingAdapter, options);
+  if (!capturer) {
+    result([FlutterError
+        errorWithCode:@"CustomVideoSourceNotRegistered"
+              message:[NSString stringWithFormat:@"Error: factory for sourceType '%@' "
+                                                 @"returned no capturer!",
+                                                 sourceType]
+              details:nil]);
+    return;
+  }
+
+  [capturer startCaptureWithWidth:width height:height fps:fps];
+
+  NSString* trackUUID = [[NSUUID UUID] UUIDString];
+  RTCVideoTrack* videoTrack = [self.peerConnectionFactory videoTrackWithSource:videoSource
+                                                                       trackId:trackUUID];
+  LocalVideoTrack* localVideoTrack = [[LocalVideoTrack alloc] initWithTrack:videoTrack
+                                                            videoProcessing:videoProcessingAdapter];
+
+  videoTrack.settings = @{
+    @"deviceId" : sourceType,
+    @"kind" : @"videoinput",
+    @"width" : [NSNumber numberWithInt:width],
+    @"height" : [NSNumber numberWithInt:height],
+    @"frameRate" : [NSNumber numberWithInt:fps],
+  };
+
+  self.customVideoCapturers[trackUUID] = capturer;
+  __weak FlutterWebRTCPlugin* weakSelf = self;
+  self.videoCapturerStopHandlers[trackUUID] = ^(CompletionHandler handler) {
+    NSLog(@"Stop custom video capturer, trackID %@", trackUUID);
+    [capturer stopCapture];
+    [weakSelf.customVideoCapturers removeObjectForKey:trackUUID];
+    handler();
+  };
+
+  [self.localTracks setObject:localVideoTrack forKey:trackUUID];
+
+  NSString* mediaStreamId = [[NSUUID UUID] UUIDString];
+  RTCMediaStream* mediaStream =
+      [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+  [mediaStream addVideoTrack:videoTrack];
+  self.localStreams[mediaStreamId] = mediaStream;
+
+  result(@{
+    @"streamId" : mediaStreamId,
+    @"audioTracks" : @[],
+    @"videoTracks" : @[ @{
+      @"id" : videoTrack.trackId,
+      @"kind" : videoTrack.kind,
+      @"label" : videoTrack.trackId,
+      @"enabled" : @(videoTrack.isEnabled),
+      @"remote" : @(YES),
+      @"readyState" : @"live",
+      @"settings" : videoTrack.settings
+    } ]
+  });
+}
+
+/**
+ * Routes an app-defined command to the {@link FlutterRTCCustomVideoCapturer} backing
+ * the custom video track identified by {@code trackId}.
+ */
+- (void)customVideoSourceCommand:(NSDictionary*)args result:(FlutterResult)result {
+  NSString* trackId = [args[@"trackId"] isKindOfClass:[NSString class]] ? args[@"trackId"] : nil;
+  NSString* command = [args[@"command"] isKindOfClass:[NSString class]] ? args[@"command"] : @"";
+  NSDictionary* commandArgs =
+      [args[@"args"] isKindOfClass:[NSDictionary class]] ? args[@"args"] : nil;
+
+  id<FlutterRTCCustomVideoCapturer> capturer =
+      trackId != nil ? self.customVideoCapturers[trackId] : nil;
+  if (!capturer) {
+    result([FlutterError
+        errorWithCode:@"CustomVideoSourceUnknownTrack"
+              message:[NSString stringWithFormat:
+                                    @"Error: no custom video capturer for trackId '%@'!", trackId]
+              details:nil]);
+    return;
+  }
+
+  NSError* error = nil;
+  id reply = [capturer handleCommand:command args:commandArgs error:&error];
+  if (error) {
+    if ([error.domain isEqualToString:FlutterRTCCustomVideoSourceErrorDomain] &&
+        error.code == FlutterRTCCustomVideoSourceErrorUnsupportedCommand) {
+      result([FlutterError
+          errorWithCode:@"CustomVideoSourceCommandUnsupported"
+                message:[NSString stringWithFormat:@"Error: command '%@' is not supported!",
+                                                   command]
+                details:nil]);
+    } else {
+      result([FlutterError errorWithCode:@"CustomVideoSourceCommandFailed"
+                                 message:error.localizedDescription
+                                 details:nil]);
+    }
+    return;
+  }
+  result(reply);
 }
 
 /**

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -7,6 +7,7 @@
 #import <Foundation/Foundation.h>
 #import <WebRTC/WebRTC.h>
 #import "LocalTrack.h"
+#import "FlutterRTCCustomVideoSource.h"
 
 @class FlutterRTCVideoRenderer;
 @class FlutterRTCFrameCapturer;
@@ -41,6 +42,12 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 @property(nonatomic, strong) NSMutableDictionary<NSNumber*, FlutterRTCMediaRecorder*>* _Nonnull recorders;
 @property(nonatomic, strong)
     NSMutableDictionary<NSString*, CapturerStopHandler>* _Nullable videoCapturerStopHandlers;
+
+/// Custom video capturers created via `createCustomVideoTrack`, keyed by
+/// trackId. Used to route `customVideoSourceCommand` calls and cleaned up by
+/// the capturer stop handler registered in `videoCapturerStopHandlers`.
+@property(nonatomic, strong)
+    NSMutableDictionary<NSString*, id<FlutterRTCCustomVideoCapturer>>* _Nullable customVideoCapturers;
 
 @property(nonatomic, strong)
     NSMutableDictionary<NSString*, RTCFrameCryptor*>* _Nullable frameCryptors;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -231,6 +231,7 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
   self.dataCryptors = [NSMutableDictionary new];
   self.keyProviders = [NSMutableDictionary new];
   self.videoCapturerStopHandlers = [NSMutableDictionary new];
+  self.customVideoCapturers = [NSMutableDictionary new];
   self.recorders = [NSMutableDictionary new];
 #if TARGET_OS_IPHONE
   self.focusMode = @"locked";
@@ -477,6 +478,12 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
                                message:@"Not supported on iOS"
                                details:nil]);
 #endif
+  } else if ([@"createCustomVideoTrack" isEqualToString:call.method]) {
+    NSDictionary* argsMap = call.arguments;
+    [self createCustomVideoTrack:argsMap result:result];
+  } else if ([@"customVideoSourceCommand" isEqualToString:call.method]) {
+    NSDictionary* argsMap = call.arguments;
+    [self customVideoSourceCommand:argsMap result:result];
   } else if ([@"createLocalMediaStream" isEqualToString:call.method]) {
     [self createLocalMediaStream:result];
   } else if ([@"getSources" isEqualToString:call.method]) {

--- a/ios/Classes/FlutterRTCCustomVideoSource.h
+++ b/ios/Classes/FlutterRTCCustomVideoSource.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/FlutterRTCCustomVideoSource.h

--- a/ios/Classes/FlutterRTCCustomVideoSource.m
+++ b/ios/Classes/FlutterRTCCustomVideoSource.m
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/FlutterRTCCustomVideoSource.m

--- a/lib/flutter_webrtc.dart
+++ b/lib/flutter_webrtc.dart
@@ -23,3 +23,5 @@ export 'src/native/android/audio_configuration.dart';
 export 'src/native/ios/audio_configuration.dart';
 export 'src/native/rtc_video_platform_view_controller.dart';
 export 'src/native/rtc_video_platform_view.dart';
+export 'src/native/custom_video_source.dart'
+    if (dart.library.js_interop) 'src/web/custom_video_source.dart';

--- a/lib/src/native/custom_video_source.dart
+++ b/lib/src/native/custom_video_source.dart
@@ -1,0 +1,72 @@
+import 'package:webrtc_interface/webrtc_interface.dart';
+
+import 'media_stream_impl.dart';
+import 'utils.dart';
+
+/// Generic API for app-provided ("custom") video sources.
+///
+/// The app registers a capturer factory on the native side
+/// (`CustomVideoSourceRegistry` on Android, `FlutterRTCCustomVideoSourceRegistry` on
+/// iOS/macOS) under a `sourceType` name, then creates a regular
+/// [MediaStream] from it via [createStream]. Runtime interaction with the
+/// capturer (e.g. `updateOverlay`, `hitTest`) goes through [command].
+///
+/// See `docs/custom-video-source.md` for the full contract.
+class CustomVideoSource {
+  CustomVideoSource._();
+
+  /// Creates a local [MediaStream] whose single video track is fed by the
+  /// custom capturer registered under [sourceType].
+  ///
+  /// Throws a [PlatformException] with code `CustomVideoSourceNotRegistered`
+  /// if no factory is registered for [sourceType].
+  static Future<MediaStream> createStream(
+    String sourceType, {
+    int width = 1280,
+    int height = 720,
+    int fps = 30,
+    Map<String, dynamic>? options,
+  }) async {
+    final response = await WebRTC.invokeMethod(
+      'createCustomVideoTrack',
+      <String, dynamic>{
+        'sourceType': sourceType,
+        'width': width,
+        'height': height,
+        'fps': fps,
+        'options': options ?? {},
+      },
+    );
+    if (response == null) {
+      throw Exception('createCustomVideoTrack returned null, something wrong');
+    }
+    return MediaStreamNative.fromMap(<dynamic, dynamic>{
+      'streamId': response['streamId'],
+      'ownerTag': response['ownerTag'] ?? 'local',
+      'audioTracks': response['audioTracks'] ?? [],
+      'videoTracks': response['videoTracks'] ?? [],
+    });
+  }
+
+  /// Sends [command] (with optional [args]) to the custom capturer backing
+  /// [track] and returns whatever the capturer implementation returns
+  /// (map/scalar/null).
+  ///
+  /// Throws a [PlatformException] with code
+  /// `CustomVideoSourceCommandUnsupported` if the capturer does not support
+  /// [command].
+  static Future<dynamic> command(
+    MediaStreamTrack track,
+    String command, [
+    Map<String, dynamic>? args,
+  ]) {
+    return WebRTC.invokeMethod(
+      'customVideoSourceCommand',
+      <String, dynamic>{
+        'trackId': track.id,
+        'command': command,
+        'args': args ?? {},
+      },
+    );
+  }
+}

--- a/lib/src/web/custom_video_source.dart
+++ b/lib/src/web/custom_video_source.dart
@@ -1,0 +1,27 @@
+import 'package:webrtc_interface/webrtc_interface.dart';
+
+/// Web stub for [CustomVideoSource]. Custom video sources are native-only
+/// (Android/iOS/macOS); every method throws [UnimplementedError] on web.
+///
+/// See `docs/custom-video-source.md` for the full contract.
+class CustomVideoSource {
+  CustomVideoSource._();
+
+  static Future<MediaStream> createStream(
+    String sourceType, {
+    int width = 1280,
+    int height = 720,
+    int fps = 30,
+    Map<String, dynamic>? options,
+  }) {
+    throw UnimplementedError('CustomVideoSource is not supported on web');
+  }
+
+  static Future<dynamic> command(
+    MediaStreamTrack track,
+    String command, [
+    Map<String, dynamic>? args,
+  ]) {
+    throw UnimplementedError('CustomVideoSource is not supported on web');
+  }
+}

--- a/macos/Classes/FlutterRTCCustomVideoSource.h
+++ b/macos/Classes/FlutterRTCCustomVideoSource.h
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/FlutterRTCCustomVideoSource.h

--- a/macos/Classes/FlutterRTCCustomVideoSource.m
+++ b/macos/Classes/FlutterRTCCustomVideoSource.m
@@ -1,0 +1,1 @@
+../../common/darwin/Classes/FlutterRTCCustomVideoSource.m


### PR DESCRIPTION
### What

Adds a registry-based **custom video source** so embedders can feed externally produced or composited frames and have them surface as a standard `MediaStreamTrack`, reusing the `getUserMedia` pipeline (shared stop path) on Android and the `VideoProcessingAdapter` chain on darwin.

- `createCustomVideoTrack` / `customVideoSourceCommand` method channel
- Android: `CustomVideoSourceRegistry` + `CustomVideoCapturer(Factory)`
- iOS/macOS: `FlutterRTCCustomVideoSource(Registry)`, routed via `FlutterWebRTCPlugin`
- Dart: `CustomVideoSource.createStream`/`command` (web throws `UnimplementedError`)
- `android/build.gradle`: expose `webrtc-sdk` via `api` (the public API surface exposes `org.webrtc` types)

### Why

Closes #2093. Complementary to #2077 (embedder factory) — this targets the frame-source side.

### Notes

- Web is intentionally stubbed (`UnimplementedError`); a browser implementation can follow.
- Public API shape is open for discussion.
- Submitted via fork; happy to iterate on review.