### PR TITLE
Expose Android audio device module

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -19,6 +19,7 @@ import com.cloudwebrtc.webrtc.utils.ConstraintsMap;
 import org.webrtc.ExternalAudioProcessingFactory;
 import org.webrtc.MediaStreamTrack;
 import org.webrtc.PeerConnectionFactory;
+import org.webrtc.audio.JavaAudioDeviceModule;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -72,6 +73,10 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
 
     public PeerConnectionFactory getPeerConnectionFactory() {
         return methodCallHandler.getPeerConnectionFactory();
+    }
+
+    public JavaAudioDeviceModule getAudioDeviceModule() {
+        return methodCallHandler.getAudioDeviceModule();
     }
 
     @Override

--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
@@ -75,8 +76,9 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
         return methodCallHandler.getPeerConnectionFactory();
     }
 
+    @Nullable
     public JavaAudioDeviceModule getAudioDeviceModule() {
-        return methodCallHandler.getAudioDeviceModule();
+        return methodCallHandler == null ? null : methodCallHandler.getAudioDeviceModule();
     }
 
     @Override

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -1566,6 +1566,10 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     return mFactory;
   }
 
+  public JavaAudioDeviceModule getAudioDeviceModule() {
+    return audioDeviceModule;
+  }
+
   @Override
   public PeerConnectionObserver getPeerConnectionObserver(String peerConnectionId) {
     return mPeerConnectionObservers.get(peerConnectionId);

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -1566,6 +1566,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     return mFactory;
   }
 
+  @Nullable
   public JavaAudioDeviceModule getAudioDeviceModule() {
     return audioDeviceModule;
   }


### PR DESCRIPTION
## Summary

Expose the Android `JavaAudioDeviceModule` from `FlutterWebRTCPlugin` through a narrow getter.

## Why

Downstream plugins that already coordinate with `FlutterWebRTCPlugin.sharedSingleton` need access to the same ADM instance that flutter-webrtc creates and passes into `PeerConnectionFactory`. This lets them start/prewarm recording with options without duplicating or replacing flutter-webrtc's ADM.

## Impact

This is an Android-only API surface for native plugin integrations. It does not change existing Dart APIs or existing start/stop recording behavior.

## Validation

- `git diff --check`