### PR TITLE
v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 [Unreleased]
 
+[1.5.2] - 2026-06-20
+
+* [Android] expose the internally managed audio device module to embedders (#2099).
+* [Windows] fix libwebrtc extraction when the plugin is loaded through a symlink (#2100).
+
 [1.5.1] - 2026-06-14
 
 * [Android] fix: recreate the texture surface when the incoming frame size changes, so simulcast layer upgrades no longer stay blurry (#2085).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_webrtc
 description: Flutter WebRTC plugin for iOS/Android/Desktop/Web, based on GoogleWebRTC.
-version: 1.5.1
+version: 1.5.2
 homepage: https://github.com/cloudwebrtc/flutter-webrtc
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
## Summary
- bump package version to 1.5.2
- add changelog entries for Android ADM exposure and Windows symlink extraction fix

## Validation
- dart pub publish --dry-run