### PR TITLE
Android: option to disable built-in hardware AEC/NS

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -205,7 +205,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     }
     mPeerConnectionObservers.clear();
   }
-  private void initialize(boolean bypassVoiceProcessing, int networkIgnoreMask, boolean forceSWCodec, List<String> forceSWCodecList,
+  private void initialize(boolean bypassVoiceProcessing, boolean androidUseHardwareAudioProcessing, int networkIgnoreMask, boolean forceSWCodec, List<String> forceSWCodecList,
   @Nullable ConstraintsMap androidAudioConfiguration, Severity logSeverity, @Nullable Integer audioSampleRate, @Nullable Integer audioOutputSampleRate) {
     if (mFactory != null) {
       return;
@@ -256,7 +256,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
                         .setUseStereoOutput(true)
                         .setAudioSource(MediaRecorder.AudioSource.MIC);
     } else {
-      boolean useHardwareAudioProcessing = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
+      boolean useHardwareAudioProcessing = androidUseHardwareAudioProcessing && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
       boolean useLowLatency = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
       audioDeviceModuleBuilder.setUseHardwareAcousticEchoCanceler(useHardwareAudioProcessing)
                         .setUseLowLatency(useLowLatency)
@@ -428,6 +428,14 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
           enableBypassVoiceProcessing = (boolean)options.get("bypassVoiceProcessing");
         }
 
+        // Defaults to true, matching the previous behaviour. Set to false to leave the
+        // platform hardware AEC/NS off so the WebRTC software APM handles echo/noise
+        // instead. Useful on devices whose built-in AEC is unreliable (#1433).
+        boolean androidUseHardwareAudioProcessing = true;
+        if(options.get("androidUseHardwareAudioProcessing") != null) {
+          androidUseHardwareAudioProcessing = (boolean)options.get("androidUseHardwareAudioProcessing");
+        }
+
         Severity logSeverity = Severity.LS_NONE;
         if (constraintsMap.hasKey("logSeverity")
                 && constraintsMap.getType("logSeverity") == ObjectType.String) {
@@ -447,7 +455,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
           audioOutputSampleRate = constraintsMap.getInt("audioOutputSampleRate");
         }
 
-        initialize(enableBypassVoiceProcessing, networkIgnoreMask, forceSWCodec, forceSWCodecList, androidAudioConfiguration, logSeverity, audioSampleRate, audioOutputSampleRate);
+        initialize(enableBypassVoiceProcessing, androidUseHardwareAudioProcessing, networkIgnoreMask, forceSWCodec, forceSWCodecList, androidAudioConfiguration, logSeverity, audioSampleRate, audioOutputSampleRate);
         result.success(null);
         break;
       }

--- a/lib/src/native/utils.dart
+++ b/lib/src/native/utils.dart
@@ -55,6 +55,10 @@ class WebRTC {
   ///
   /// "bypassVoiceProcessing": a boolean that bypasses the audio processing for the audio device.
   ///
+  /// "androidUseHardwareAudioProcessing": (Android only) defaults to true. Set to false to leave
+  ///                    the platform hardware AEC/NS off and let the WebRTC software APM handle
+  ///                    echo/noise instead (useful when a device's built-in AEC is unreliable).
+  ///
   /// "audioSampleRate": (Android only) Sets both input and output sample rate in Hz (e.g., 48000).
   ///                    If not specified, uses the native device's default sample rate.
   ///


### PR DESCRIPTION
Adds an `androidUseHardwareAudioProcessing` init option (default `true`, so nothing changes unless you opt in). When set to `false`, the `JavaAudioDeviceModule` is built with the platform `AcousticEchoCanceler`/`NoiseSuppressor` off, and the WebRTC software APM handles echo/noise instead:

```dart
await WebRTC.initialize(options: {'androidUseHardwareAudioProcessing': false});
```

The built-in hardware AEC is unreliable on quite a few Android devices — you get echo that AEC3 would otherwise cancel (#1433). Today the only way to turn it off is `bypassVoiceProcessing`, but that also switches the input to the raw `AudioSource.MIC` and forces stereo in/out — a full raw-capture path that's overkill when all you want is for the software APM to run on an otherwise-normal voice call. This flag leaves the audio source (and everything else) exactly as it is and only flips the two hardware-effect flags.

It's the same control the native LiveKit Android SDK (`javaAudioDeviceModuleCustomizer`) and react-native-webrtc (react-native-webrtc/react-native-webrtc#713) already expose; this brings it to flutter_webrtc.

Tested on a Realme device whose earpiece hardware AEC leaked badly: with the flag off, AEC3 converges and the echo clears. With it unset/`true`, behaviour is unchanged.
