### PR TITLE
feat: expose microphone mute mode and ADM-level microphone mute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 [Unreleased]
 
+* [Darwin] feat: expose the audio device module's microphone mute mode (`Helper.setMicrophoneMuteMode` / `Helper.getMicrophoneMuteMode`). `voiceProcessing` (the default) plays the platform mute tone on mute/unmute; `inputMixer` and `restartEngine` mute silently (#2098).
+* [Darwin/Android] feat: add ADM-level microphone mute (`Helper.setMicrophoneMuted` / `Helper.isMicrophoneMuted`), independent of `MediaStreamTrack.enabled`.
+
 [1.5.2] - 2026-06-20
 
 * [Android] expose the internally managed audio device module to embedders (#2099).

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -130,6 +130,10 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
 
   private JavaAudioDeviceModule audioDeviceModule;
 
+  // JavaAudioDeviceModule has no mute getter, so mirror the last value set
+  // via the "setMicrophoneMuted" method call.
+  private boolean microphoneMuted = false;
+
   private FlutterRTCFrameCryptor frameCryptor;
 
   private FlutterDataPacketCryptor dataPacketCryptor;
@@ -1143,6 +1147,21 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
             result.success(null);
           });
         });
+        break;
+      }
+      case "setMicrophoneMuted": {
+        boolean muted = call.argument("muted");
+        if (audioDeviceModule == null) {
+          resultError("setMicrophoneMuted", "audioDeviceModule is null", result);
+          break;
+        }
+        audioDeviceModule.setMicrophoneMute(muted);
+        microphoneMuted = muted;
+        result.success(null);
+        break;
+      }
+      case "isMicrophoneMuted": {
+        result.success(microphoneMuted);
         break;
       }
       case "setLogSeverity": {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -1150,7 +1150,11 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
         break;
       }
       case "setMicrophoneMuted": {
-        boolean muted = call.argument("muted");
+        Boolean muted = call.argument("muted");
+        if (muted == null) {
+          resultError("setMicrophoneMuted", "muted is required", result);
+          break;
+        }
         if (audioDeviceModule == null) {
           resultError("setMicrophoneMuted", "audioDeviceModule is null", result);
           break;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1776,33 +1776,55 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
       NSString* modeString = call.arguments[@"mode"];
       RTCAudioEngineMuteMode mode = [FlutterWebRTCPlugin muteModeForString:modeString];
       if (mode == RTCAudioEngineMuteModeUnknown) {
-        result([FlutterError errorWithCode:@"setMicrophoneMuteMode failed"
+        result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@ failed", call.method]
                                    message:[NSString stringWithFormat:@"Error: invalid mute mode: %@", modeString]
                                    details:nil]);
         return;
       }
-      NSInteger admResult = [adm setMuteMode:mode];
-      if (admResult == 0) {
-        result(nil);
-      } else {
-        result([FlutterError errorWithCode:@"setMicrophoneMuteMode failed"
-                                   message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld", (long)admResult]
-                                   details:nil]);
-      }
+      // With mode restartEngine a mute-state transition rebuilds the audio
+      // engine, so keep this off the platform thread like the recording APIs.
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSInteger admResult = [adm setMuteMode:mode];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          if (admResult == 0) {
+            result(nil);
+          } else {
+            result([FlutterError
+                errorWithCode:[NSString stringWithFormat:@"%@ failed", call.method]
+                      message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld",
+                                                         (long)admResult]
+                      details:nil]);
+          }
+        });
+      });
     } else if ([@"isMicrophoneMuted" isEqualToString:call.method]) {
       RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
       result([NSNumber numberWithBool:adm.isMicrophoneMuted]);
     } else if ([@"setMicrophoneMuted" isEqualToString:call.method]) {
       RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
       NSNumber* muted = call.arguments[@"muted"];
-      NSInteger admResult = [adm setMicrophoneMuted:muted.boolValue];
-      if (admResult == 0) {
-        result(nil);
-      } else {
-        result([FlutterError errorWithCode:@"setMicrophoneMuted failed"
-                                   message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld", (long)admResult]
+      if (![muted isKindOfClass:[NSNumber class]]) {
+        result([FlutterError errorWithCode:[NSString stringWithFormat:@"%@ failed", call.method]
+                                   message:@"Error: muted is required"
                                    details:nil]);
+        return;
       }
+      // With mode restartEngine muting rebuilds the audio engine, so keep
+      // this off the platform thread like the recording APIs.
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        NSInteger admResult = [adm setMicrophoneMuted:muted.boolValue];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          if (admResult == 0) {
+            result(nil);
+          } else {
+            result([FlutterError
+                errorWithCode:[NSString stringWithFormat:@"%@ failed", call.method]
+                      message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld",
+                                                         (long)admResult]
+                      details:nil]);
+          }
+        });
+      });
     } else {
       if([self handleFrameCryptorMethodCall:call result:result]) {
           return;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -151,6 +151,30 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
   gAudioSessionManagementEnabled = enabled;
 }
 
++ (NSString*)stringForMuteMode:(RTCAudioEngineMuteMode)mode {
+  switch (mode) {
+    case RTCAudioEngineMuteModeVoiceProcessing:
+      return @"voiceProcessing";
+    case RTCAudioEngineMuteModeRestartEngine:
+      return @"restartEngine";
+    case RTCAudioEngineMuteModeInputMixer:
+      return @"inputMixer";
+    case RTCAudioEngineMuteModeUnknown:
+      return @"unknown";
+  }
+}
+
++ (RTCAudioEngineMuteMode)muteModeForString:(NSString*)mode {
+  if ([mode isEqualToString:@"voiceProcessing"]) {
+    return RTCAudioEngineMuteModeVoiceProcessing;
+  } else if ([mode isEqualToString:@"restartEngine"]) {
+    return RTCAudioEngineMuteModeRestartEngine;
+  } else if ([mode isEqualToString:@"inputMixer"]) {
+    return RTCAudioEngineMuteModeInputMixer;
+  }
+  return RTCAudioEngineMuteModeUnknown;
+}
+
 + (void)setAudioDeviceModuleObserver:(id<RTCAudioDeviceModuleDelegate>)observer {
   gAudioDeviceModuleObserver = observer;
 }
@@ -1744,6 +1768,41 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
       NSNumber* value = call.arguments[@"value"];
       adm.voiceProcessingBypassed = value.boolValue;
       result(nil);
+    } else if ([@"getMicrophoneMuteMode" isEqualToString:call.method]) {
+      RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
+      result([FlutterWebRTCPlugin stringForMuteMode:adm.muteMode]);
+    } else if ([@"setMicrophoneMuteMode" isEqualToString:call.method]) {
+      RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
+      NSString* modeString = call.arguments[@"mode"];
+      RTCAudioEngineMuteMode mode = [FlutterWebRTCPlugin muteModeForString:modeString];
+      if (mode == RTCAudioEngineMuteModeUnknown) {
+        result([FlutterError errorWithCode:@"setMicrophoneMuteMode failed"
+                                   message:[NSString stringWithFormat:@"Error: invalid mute mode: %@", modeString]
+                                   details:nil]);
+        return;
+      }
+      NSInteger admResult = [adm setMuteMode:mode];
+      if (admResult == 0) {
+        result(nil);
+      } else {
+        result([FlutterError errorWithCode:@"setMicrophoneMuteMode failed"
+                                   message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld", (long)admResult]
+                                   details:nil]);
+      }
+    } else if ([@"isMicrophoneMuted" isEqualToString:call.method]) {
+      RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
+      result([NSNumber numberWithBool:adm.isMicrophoneMuted]);
+    } else if ([@"setMicrophoneMuted" isEqualToString:call.method]) {
+      RTCAudioDeviceModule* adm = _peerConnectionFactory.audioDeviceModule;
+      NSNumber* muted = call.arguments[@"muted"];
+      NSInteger admResult = [adm setMicrophoneMuted:muted.boolValue];
+      if (admResult == 0) {
+        result(nil);
+      } else {
+        result([FlutterError errorWithCode:@"setMicrophoneMuted failed"
+                                   message:[NSString stringWithFormat:@"Error: adm api failed with code: %ld", (long)admResult]
+                                   details:nil]);
+      }
     } else {
       if([self handleFrameCryptorMethodCall:call result:result]) {
           return;

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -158,6 +158,30 @@ class Helper {
   static Future<void> setMicrophoneMute(bool mute, MediaStreamTrack track) =>
       NativeAudioManagement.setMicrophoneMute(mute, track);
 
+  /// Get how the audio device module mutes microphone input.
+  /// for iOS/macOS only, returns [MicrophoneMuteMode.unknown] elsewhere.
+  static Future<MicrophoneMuteMode> getMicrophoneMuteMode() =>
+      NativeAudioManagement.getMicrophoneMuteMode();
+
+  /// Set how the audio device module mutes microphone input.
+  /// for iOS/macOS only. [MicrophoneMuteMode.voiceProcessing] (the default)
+  /// plays the platform mute sound effect on mute/unmute; use
+  /// [MicrophoneMuteMode.inputMixer] or [MicrophoneMuteMode.restartEngine]
+  /// for silent muting.
+  static Future<void> setMicrophoneMuteMode(MicrophoneMuteMode mode) =>
+      NativeAudioManagement.setMicrophoneMuteMode(mode);
+
+  /// Get whether microphone input is muted at the audio device module level.
+  /// Unrelated to `MediaStreamTrack.enabled`.
+  static Future<bool> isMicrophoneMuted() =>
+      NativeAudioManagement.isMicrophoneMuted();
+
+  /// Mute or unmute microphone input at the audio device module level,
+  /// honoring the mode set via [setMicrophoneMuteMode] on iOS/macOS.
+  /// Unrelated to `MediaStreamTrack.enabled`.
+  static Future<void> setMicrophoneMuted(bool muted) =>
+      NativeAudioManagement.setMicrophoneMuted(muted);
+
   /// Set the audio configuration to for Android.
   /// Must be set before initiating a WebRTC session and cannot be changed
   /// mid session.

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -159,26 +159,36 @@ class Helper {
       NativeAudioManagement.setMicrophoneMute(mute, track);
 
   /// Get how the audio device module mutes microphone input.
-  /// for iOS/macOS only, returns [MicrophoneMuteMode.unknown] elsewhere.
+  ///
+  /// iOS/macOS only. On all other platforms this returns
+  /// [MicrophoneMuteMode.unknown] without calling into native code, so it is
+  /// always safe to call from cross-platform code.
   static Future<MicrophoneMuteMode> getMicrophoneMuteMode() =>
       NativeAudioManagement.getMicrophoneMuteMode();
 
   /// Set how the audio device module mutes microphone input.
-  /// for iOS/macOS only. [MicrophoneMuteMode.voiceProcessing] (the default)
-  /// plays the platform mute sound effect on mute/unmute; use
-  /// [MicrophoneMuteMode.inputMixer] or [MicrophoneMuteMode.restartEngine]
-  /// for silent muting.
+  ///
+  /// [MicrophoneMuteMode.voiceProcessing] (the default) plays the platform
+  /// mute sound effect on mute/unmute; use [MicrophoneMuteMode.inputMixer] or
+  /// [MicrophoneMuteMode.restartEngine] for silent muting.
+  ///
+  /// iOS/macOS only. On all other platforms this is a no-op that completes
+  /// normally, so it is always safe to call from cross-platform code.
   static Future<void> setMicrophoneMuteMode(MicrophoneMuteMode mode) =>
       NativeAudioManagement.setMicrophoneMuteMode(mode);
 
   /// Get whether microphone input is muted at the audio device module level.
   /// Unrelated to `MediaStreamTrack.enabled`.
+  ///
+  /// Supported on iOS/macOS and Android; on web this returns `false`.
   static Future<bool> isMicrophoneMuted() =>
       NativeAudioManagement.isMicrophoneMuted();
 
   /// Mute or unmute microphone input at the audio device module level,
   /// honoring the mode set via [setMicrophoneMuteMode] on iOS/macOS.
   /// Unrelated to `MediaStreamTrack.enabled`.
+  ///
+  /// Supported on iOS/macOS and Android; on web this is a no-op.
   static Future<void> setMicrophoneMuted(bool muted) =>
       NativeAudioManagement.setMicrophoneMuted(muted);
 

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -173,14 +173,16 @@ class Helper {
   /// [MicrophoneMuteMode.restartEngine] for silent muting.
   ///
   /// iOS/macOS only. On all other platforms this is a no-op that completes
-  /// normally, so it is always safe to call from cross-platform code.
+  /// normally (including for [MicrophoneMuteMode.unknown]), so it is always
+  /// safe to call from cross-platform code.
   static Future<void> setMicrophoneMuteMode(MicrophoneMuteMode mode) =>
       NativeAudioManagement.setMicrophoneMuteMode(mode);
 
   /// Get whether microphone input is muted at the audio device module level.
   /// Unrelated to `MediaStreamTrack.enabled`.
   ///
-  /// Supported on iOS/macOS and Android; on web this returns `false`.
+  /// Supported on iOS/macOS and Android; on all other platforms this returns
+  /// `false` without calling into native code.
   static Future<bool> isMicrophoneMuted() =>
       NativeAudioManagement.isMicrophoneMuted();
 
@@ -188,7 +190,8 @@ class Helper {
   /// honoring the mode set via [setMicrophoneMuteMode] on iOS/macOS.
   /// Unrelated to `MediaStreamTrack.enabled`.
   ///
-  /// Supported on iOS/macOS and Android; on web this is a no-op.
+  /// Supported on iOS/macOS and Android; on all other platforms this is a
+  /// no-op that completes normally.
   static Future<void> setMicrophoneMuted(bool muted) =>
       NativeAudioManagement.setMicrophoneMuted(muted);
 

--- a/lib/src/native/audio_management.dart
+++ b/lib/src/native/audio_management.dart
@@ -6,6 +6,25 @@ import 'package:webrtc_interface/webrtc_interface.dart';
 import 'media_stream_track_impl.dart';
 import 'utils.dart';
 
+/// Strategy used by the AVAudioEngine-based audio device module to mute
+/// microphone input. iOS/macOS only.
+enum MicrophoneMuteMode {
+  /// Mute using Voice Processing I/O's input mute. Fast and allows muted
+  /// talker detection, but plays the platform's mute/unmute sound effect.
+  voiceProcessing,
+
+  /// Mute by restarting the audio engine without microphone input. Slower,
+  /// but silent and stops microphone input entirely while muted.
+  restartEngine,
+
+  /// Mute by muting the engine's input mixer node. Fast and silent; the
+  /// engine and audio session keep running.
+  inputMixer,
+
+  /// The mode could not be determined (e.g. unsupported platform).
+  unknown,
+}
+
 class NativeAudioManagement {
   static Future<void> selectAudioInput(String deviceId) async {
     await WebRTC.invokeMethod(
@@ -132,6 +151,78 @@ class NativeAudioManagement {
       );
     } on PlatformException catch (e) {
       throw 'Unable to set isVoiceProcessingBypassed: ${e.message}';
+    }
+  }
+
+  /// Returns the current microphone mute mode of the audio device module.
+  /// iOS/macOS only; returns [MicrophoneMuteMode.unknown] elsewhere.
+  static Future<MicrophoneMuteMode> getMicrophoneMuteMode() async {
+    if (!WebRTC.platformIsIOS && !WebRTC.platformIsMacOS) {
+      return MicrophoneMuteMode.unknown;
+    }
+
+    try {
+      final result = await WebRTC.invokeMethod(
+        'getMicrophoneMuteMode',
+        <String, dynamic>{},
+      );
+      return MicrophoneMuteMode.values.firstWhere(
+        (mode) => mode.name == result,
+        orElse: () => MicrophoneMuteMode.unknown,
+      );
+    } on PlatformException catch (e) {
+      throw 'Unable to get microphoneMuteMode: ${e.message}';
+    }
+  }
+
+  /// Sets how the audio device module mutes microphone input.
+  /// iOS/macOS only; no-op elsewhere.
+  static Future<void> setMicrophoneMuteMode(MicrophoneMuteMode mode) async {
+    if (!WebRTC.platformIsIOS && !WebRTC.platformIsMacOS) return;
+
+    if (mode == MicrophoneMuteMode.unknown) {
+      throw ArgumentError.value(mode, 'mode', 'Not a settable mute mode');
+    }
+
+    try {
+      await WebRTC.invokeMethod(
+        'setMicrophoneMuteMode',
+        <String, dynamic>{'mode': mode.name},
+      );
+    } on PlatformException catch (e) {
+      throw 'Unable to set microphoneMuteMode: ${e.message}';
+    }
+  }
+
+  /// Returns whether microphone input is muted at the audio device module
+  /// level. Unrelated to `MediaStreamTrack.enabled`.
+  static Future<bool> isMicrophoneMuted() async {
+    if (kIsWeb) return false;
+
+    try {
+      final result = await WebRTC.invokeMethod(
+        'isMicrophoneMuted',
+        <String, dynamic>{},
+      );
+      return result as bool;
+    } on PlatformException catch (e) {
+      throw 'Unable to get isMicrophoneMuted: ${e.message}';
+    }
+  }
+
+  /// Mutes or unmutes microphone input at the audio device module level.
+  /// On iOS/macOS the muting strategy is controlled by
+  /// [setMicrophoneMuteMode]. Unrelated to `MediaStreamTrack.enabled`.
+  static Future<void> setMicrophoneMuted(bool muted) async {
+    if (kIsWeb) return;
+
+    try {
+      await WebRTC.invokeMethod(
+        'setMicrophoneMuted',
+        <String, dynamic>{'muted': muted},
+      );
+    } on PlatformException catch (e) {
+      throw 'Unable to set isMicrophoneMuted: ${e.message}';
     }
   }
 }

--- a/lib/src/native/audio_management.dart
+++ b/lib/src/native/audio_management.dart
@@ -157,6 +157,12 @@ class NativeAudioManagement {
   static bool get _supportsMicrophoneMuteMode =>
       !kIsWeb && (WebRTC.platformIsIOS || WebRTC.platformIsMacOS);
 
+  static bool get _supportsAdmMicrophoneMute =>
+      !kIsWeb &&
+      (WebRTC.platformIsIOS ||
+          WebRTC.platformIsMacOS ||
+          WebRTC.platformIsAndroid);
+
   /// Returns the current microphone mute mode of the audio device module.
   ///
   /// iOS/macOS only. On all other platforms (Android, web, desktop) this
@@ -185,14 +191,11 @@ class NativeAudioManagement {
   ///
   /// iOS/macOS only. On all other platforms (Android, web, desktop) this is
   /// a no-op that completes normally, so it is always safe to call from
-  /// cross-platform code.
-  ///
-  /// Throws [ArgumentError] if [mode] is [MicrophoneMuteMode.unknown], which
-  /// is a read-only value and not a settable mode.
+  /// cross-platform code. Passing [MicrophoneMuteMode.unknown] (the value
+  /// [getMicrophoneMuteMode] reports on unsupported platforms) is also a
+  /// no-op, so `set(await get())` round-trips safely everywhere.
   static Future<void> setMicrophoneMuteMode(MicrophoneMuteMode mode) async {
-    if (mode == MicrophoneMuteMode.unknown) {
-      throw ArgumentError.value(mode, 'mode', 'Not a settable mute mode');
-    }
+    if (mode == MicrophoneMuteMode.unknown) return;
 
     if (!_supportsMicrophoneMuteMode) return;
 
@@ -209,9 +212,10 @@ class NativeAudioManagement {
   /// Returns whether microphone input is muted at the audio device module
   /// level. Unrelated to `MediaStreamTrack.enabled`.
   ///
-  /// Supported on iOS/macOS and Android; on web this returns `false`.
+  /// Supported on iOS/macOS and Android; on all other platforms this returns
+  /// `false` without calling into native code.
   static Future<bool> isMicrophoneMuted() async {
-    if (kIsWeb) return false;
+    if (!_supportsAdmMicrophoneMute) return false;
 
     try {
       final result = await WebRTC.invokeMethod(
@@ -228,9 +232,10 @@ class NativeAudioManagement {
   /// Unrelated to `MediaStreamTrack.enabled`.
   ///
   /// Supported on iOS/macOS (where the muting strategy is controlled by
-  /// [setMicrophoneMuteMode]) and Android; on web this is a no-op.
+  /// [setMicrophoneMuteMode]) and Android; on all other platforms this is a
+  /// no-op that completes normally.
   static Future<void> setMicrophoneMuted(bool muted) async {
-    if (kIsWeb) return;
+    if (!_supportsAdmMicrophoneMute) return;
 
     try {
       await WebRTC.invokeMethod(

--- a/lib/src/native/audio_management.dart
+++ b/lib/src/native/audio_management.dart
@@ -154,10 +154,16 @@ class NativeAudioManagement {
     }
   }
 
+  static bool get _supportsMicrophoneMuteMode =>
+      !kIsWeb && (WebRTC.platformIsIOS || WebRTC.platformIsMacOS);
+
   /// Returns the current microphone mute mode of the audio device module.
-  /// iOS/macOS only; returns [MicrophoneMuteMode.unknown] elsewhere.
+  ///
+  /// iOS/macOS only. On all other platforms (Android, web, desktop) this
+  /// returns [MicrophoneMuteMode.unknown] without calling into native code,
+  /// so it is always safe to call from cross-platform code.
   static Future<MicrophoneMuteMode> getMicrophoneMuteMode() async {
-    if (!WebRTC.platformIsIOS && !WebRTC.platformIsMacOS) {
+    if (!_supportsMicrophoneMuteMode) {
       return MicrophoneMuteMode.unknown;
     }
 
@@ -176,13 +182,19 @@ class NativeAudioManagement {
   }
 
   /// Sets how the audio device module mutes microphone input.
-  /// iOS/macOS only; no-op elsewhere.
+  ///
+  /// iOS/macOS only. On all other platforms (Android, web, desktop) this is
+  /// a no-op that completes normally, so it is always safe to call from
+  /// cross-platform code.
+  ///
+  /// Throws [ArgumentError] if [mode] is [MicrophoneMuteMode.unknown], which
+  /// is a read-only value and not a settable mode.
   static Future<void> setMicrophoneMuteMode(MicrophoneMuteMode mode) async {
-    if (!WebRTC.platformIsIOS && !WebRTC.platformIsMacOS) return;
-
     if (mode == MicrophoneMuteMode.unknown) {
       throw ArgumentError.value(mode, 'mode', 'Not a settable mute mode');
     }
+
+    if (!_supportsMicrophoneMuteMode) return;
 
     try {
       await WebRTC.invokeMethod(
@@ -196,6 +208,8 @@ class NativeAudioManagement {
 
   /// Returns whether microphone input is muted at the audio device module
   /// level. Unrelated to `MediaStreamTrack.enabled`.
+  ///
+  /// Supported on iOS/macOS and Android; on web this returns `false`.
   static Future<bool> isMicrophoneMuted() async {
     if (kIsWeb) return false;
 
@@ -211,8 +225,10 @@ class NativeAudioManagement {
   }
 
   /// Mutes or unmutes microphone input at the audio device module level.
-  /// On iOS/macOS the muting strategy is controlled by
-  /// [setMicrophoneMuteMode]. Unrelated to `MediaStreamTrack.enabled`.
+  /// Unrelated to `MediaStreamTrack.enabled`.
+  ///
+  /// Supported on iOS/macOS (where the muting strategy is controlled by
+  /// [setMicrophoneMuteMode]) and Android; on web this is a no-op.
   static Future<void> setMicrophoneMuted(bool muted) async {
     if (kIsWeb) return;
 


### PR DESCRIPTION
## Description

Adds control over how the AVAudioEngine-based audio device module mutes microphone input, and ADM-level mute APIs independent of `MediaStreamTrack.enabled`.

Fixes #2098.

## Background

Since 1.5.0 the Darwin factory uses the AVAudioEngine audio device module, whose default mute strategy is `voiceProcessing` (`AVAudioInputNode.isVoiceProcessingInputMuted`). That strategy plays the platform's mute/unmute sound effect, which is the regression reported in #2098. The underlying WebRTC-SDK binaries (144.7559.09, already pinned) ship alternative mute modes, but the plugin had no API to select them.

## API

```dart
// iOS/macOS: choose the muting strategy (no-op elsewhere)
await Helper.setMicrophoneMuteMode(MicrophoneMuteMode.inputMixer);
final mode = await Helper.getMicrophoneMuteMode();

// ADM-level mute, independent of track.enabled (Darwin + Android)
await Helper.setMicrophoneMuted(true);
final muted = await Helper.isMicrophoneMuted();
```

Mute modes (Darwin only):
- `voiceProcessing` (default) — fast, keeps muted-talker detection possible, but plays the platform mute tone.
- `inputMixer` — mutes the engine's input mixer node; fast and silent, engine keeps running.
- `restartEngine` — restarts the engine without mic input; slower, silent, stops mic input entirely while muted.

The default is unchanged; apps opt into the silent modes.

## Implementation notes

- Darwin: method-channel handlers call `RTCAudioDeviceModule` `muteMode`/`setMuteMode:`/`isMicrophoneMuted`/`setMicrophoneMuted:`, following the existing voice-processing handler pattern.
- Android: `setMicrophoneMuted` maps to `JavaAudioDeviceModule.setMicrophoneMute` (mute mode is not applicable). The Java ADM has no mute getter, so the plugin mirrors the last set value for `isMicrophoneMuted`.
- Unsupported platforms: `setMicrophoneMuteMode` is a no-op and `getMicrophoneMuteMode` returns `unknown`; web is a no-op for all four APIs.

## Testing

- `dart analyze` clean.
- macOS and Android example builds pass against the pinned WebRTC-SDK 144.7559.09 (no native dependency bump required).