### PR TITLE
Feat: Custom LocalVideoTrack - with this changes we can create a videoTrack on the native side of ios and android and attach it to a mediaStream

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -21,6 +21,7 @@ import org.webrtc.ExternalAudioProcessingFactory;
 import org.webrtc.MediaStreamTrack;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.audio.JavaAudioDeviceModule;
+import org.webrtc.VideoTrack;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -50,11 +51,20 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
     // FlutterWebRTCPlugin instance, so for the next instances eventSink will be == null
     public static EventChannel.EventSink eventSink;
 
+    private VideoTrackFactory videoTrackFactory;
+
     public FlutterWebRTCPlugin() {
         sharedSingleton = this;
     }
 
     public static FlutterWebRTCPlugin sharedSingleton;
+
+    public void setVideoTrackFactory(VideoTrackFactory factory) {
+        videoTrackFactory = factory;
+        if (methodCallHandler != null) {
+            methodCallHandler.videoTrackFactory = factory;
+        }
+    }
 
     public AudioProcessingController getAudioProcessingController() {
         return methodCallHandler.audioProcessingController;
@@ -126,6 +136,7 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
                                 TextureRegistry textureRegistry) {
         AudioSwitchManager.instance = new AudioSwitchManager(context);
         methodCallHandler = new MethodCallHandlerImpl(context, messenger, textureRegistry);
+        methodCallHandler.videoTrackFactory = videoTrackFactory;
         methodChannel = new MethodChannel(messenger, "FlutterWebRTC.Method");
         methodChannel.setMethodCallHandler(methodCallHandler);
         eventChannel = new EventChannel( messenger,"FlutterWebRTC.Event");

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -142,6 +142,8 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
 
   public AudioProcessingController audioProcessingController;
 
+  public VideoTrackFactory videoTrackFactory;
+
   public static class LogSink implements Loggable {
     @Override
     public void onLogMessage(String message, Severity sev, String tag) {
@@ -469,6 +471,10 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
       }
       case "createLocalMediaStream":
         createLocalMediaStream(result);
+        break;
+      case "createLocalMediaStreamWithCustomVideoTrack":
+        String customTrackName = call.argument("named");
+        createLocalMediaStreamWithCustomVideoTrack(customTrackName, result);
         break;
       case "getSources":
         getSources(result);
@@ -1746,6 +1752,21 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     result.success(resultMap);
   }
 
+  private void createLocalMediaStreamWithCustomVideoTrack(String name, Result result) {
+    String streamId = getNextStreamUUID();
+    MediaStream mediaStream = mFactory.createLocalMediaStream(streamId);
+    VideoTrack videoTrack = videoTrackFactory.videoTrackNamed(name, mFactory);
+    mediaStream.addTrack(videoTrack);
+    localStreams.put(streamId, mediaStream);
+
+    if (mediaStream == null) {
+      resultError("createLocalMediaStream", "Failed to create new media stream", result);
+      return;
+      }
+      Map<String, Object> resultMap = new HashMap<>();
+      resultMap.put("streamId", mediaStream.getId());
+      result.success(resultMap);
+    }
   public void trackDispose(final String trackId) {
     LocalTrack track;
     synchronized (localTracks) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/VideoTrackFactory.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/VideoTrackFactory.java
@@ -1,0 +1,8 @@
+package com.cloudwebrtc.webrtc;
+
+import org.webrtc.VideoTrack;
+import org.webrtc.PeerConnectionFactory;
+
+public interface VideoTrackFactory {
+    VideoTrack videoTrackNamed(String name, PeerConnectionFactory factory);
+}

--- a/common/darwin/Classes/FlutterRTCMediaStream.h
+++ b/common/darwin/Classes/FlutterRTCMediaStream.h
@@ -11,6 +11,9 @@
 
 - (void)createLocalMediaStream:(nonnull FlutterResult)result;
 
+- (void)createLocalMediaStreamWithCustomVideoTrack:(nonnull RTCVideoTrack*)track
+                                            result:(nonnull FlutterResult)result;
+
 - (void)getSources:(nonnull FlutterResult)result;
 
 - (void)mediaStreamTrackCaptureFrame:(nonnull RTCMediaStreamTrack*)track

--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -681,6 +681,17 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
   result(@{@"streamId" : [mediaStream streamId]});
 }
 
+- (void)createLocalMediaStreamWithCustomVideoTrack:(nonnull RTCVideoTrack*)track
+                                            result:(FlutterResult)result {
+  NSString* mediaStreamId = [[NSUUID UUID] UUIDString];
+  RTCMediaStream* mediaStream = [self.peerConnectionFactory mediaStreamWithStreamId:mediaStreamId];
+
+  [mediaStream addVideoTrack:track];
+    
+  self.localStreams[mediaStreamId] = mediaStream;
+  result(@{@"streamId" : [mediaStream streamId]});
+}
+
 - (void)getSources:(FlutterResult)result {
   NSMutableArray* sources = [NSMutableArray array];
   NSArray* videoDevices =  [self captureDevices];

--- a/common/darwin/Classes/FlutterWebRTCPlugin.h
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.h
@@ -17,6 +17,8 @@ void postEvent(FlutterEventSink _Nullable sink, id _Nullable event);
 
 typedef void (^CompletionHandler)(void);
 
+typedef RTCVideoTrack * _Nullable (^VideoTrackFactory)(NSString * _Nonnull name, RTCPeerConnectionFactory * _Nonnull factory);
+
 typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 
 @interface FlutterWebRTCPlugin : NSObject <FlutterPlugin,
@@ -59,6 +61,7 @@ typedef void (^CapturerStopHandler)(CompletionHandler _Nonnull handler);
 @property(nonatomic, strong) RTCCameraVideoCapturer* _Nullable videoCapturer;
 @property(nonatomic, strong) FlutterRTCFrameCapturer* _Nullable frameCapturer;
 @property(nonatomic, strong) AVAudioSessionPort _Nullable preferredInput;
+@property(nonatomic) VideoTrackFactory _Nullable videoTrackFactory;
 
 @property(nonatomic, strong) NSString* _Nonnull focusMode;
 @property(nonatomic, strong) NSString* _Nonnull exposureMode;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -479,6 +479,11 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
 #endif
   } else if ([@"createLocalMediaStream" isEqualToString:call.method]) {
     [self createLocalMediaStream:result];
+  } else if ([@"createLocalMediaStreamWithCustomVideoTrack" isEqualToString:call.method]) {
+    NSDictionary* argsMap = call.arguments;
+    NSString* customTrackName = argsMap[@"named"];
+    RTCVideoTrack* videoTrack = _videoTrackFactory(customTrackName, _peerConnectionFactory);
+    [self createLocalMediaStreamWithCustomVideoTrack:videoTrack result:result];
   } else if ([@"getSources" isEqualToString:call.method]) {
     [self getSources:result];
   } else if ([@"selectAudioInput" isEqualToString:call.method]) {

--- a/lib/src/native/factory_impl.dart
+++ b/lib/src/native/factory_impl.dart
@@ -28,6 +28,24 @@ class RTCFactoryNative extends RTCFactory {
     return MediaStreamNative(response['streamId'], label);
   }
 
+  Future<MediaStream> createLocalMediaStreamWithCustomVideoTrack(
+      String label,
+      String name) async {
+    final response = await WebRTC.invokeMethod(
+      'createLocalMediaStreamWithCustomVideoTrack',
+      <String, dynamic>{
+        'named': name,
+      },
+    );
+    if (response == null) {
+      throw Exception('createLocalMediaStreamWithCustomVideoTrack return null, something wrong');
+    }
+
+    final stream = MediaStreamNative(response['streamId'], label);
+    await stream.getMediaTracks();
+    return stream;
+  }
+
   @override
   Future<RTCPeerConnection> createPeerConnection(
       Map<String, dynamic> configuration,
@@ -100,6 +118,10 @@ Future<RTCPeerConnection> createPeerConnection(
 
 Future<MediaStream> createLocalMediaStream(String label) async {
   return RTCFactoryNative.instance.createLocalMediaStream(label);
+}
+
+Future<MediaStream> createLocalMediaStreamWithCustomVideoTrack(String label, String name) async {
+  return RTCFactoryNative.instance.createLocalMediaStreamWithCustomVideoTrack(label, name);
 }
 
 Future<RTCRtpCapabilities> getRtpReceiverCapabilities(String kind) async {


### PR DESCRIPTION
Use case:
sending a static image or pre recorded video (no audio yet) though a webrtc connection
sending a static image when the OS cuts access to the camera due to the app being minimized

(Android) FlutterWebRTCPlugin.sharedInstance.setVideoTrackFactory()
(iOS) FlutterWebRTCPlugin.sharedInstance.videoTrackFactory
by setting a video track factory, the flutter plugin can later obtain a customize videoTrack and add it to a mediaStream
videoTrackFactory can provide different custom VideoTrack based on a name

factory_impl.dart createLocalMediaStreamWithCustomVideoTrack()
calls a method channel that will create a local MediaStream and attach a custom VideoTrack to it, the custom VideoTrack will be generated by videoTrackFactory

