### PR TITLE
exposing public MediaStream getStreamForId in FlutterWebRTCPlugin.java

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterWebRTCPlugin.java
@@ -18,6 +18,7 @@ import com.cloudwebrtc.webrtc.utils.AnyThreadSink;
 import com.cloudwebrtc.webrtc.utils.ConstraintsMap;
 
 import org.webrtc.ExternalAudioProcessingFactory;
+import org.webrtc.MediaStream;
 import org.webrtc.MediaStreamTrack;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.audio.JavaAudioDeviceModule;
@@ -62,6 +63,10 @@ public class FlutterWebRTCPlugin implements FlutterPlugin, ActivityAware, EventC
 
     public MediaStreamTrack getTrackForId(String trackId, String peerConnectionId) {
         return methodCallHandler.getTrackForId(trackId, peerConnectionId);
+    }
+
+    public MediaStream getStreamForId(String streamId, String peerConnectionId) {
+        return methodCallHandler.getStreamForId(streamId, peerConnectionId);
     }
 
     public LocalTrack getLocalTrack(String trackId) {


### PR DESCRIPTION
the same method is already exposed on the iOS implementation. i use this method to inject a custom video track in to the MediaStream to be able to send it through the webrtc connection.