### PR TITLE
fix(android): NPE in setFocusPoint/setExposurePoint — orientation cache is never populated

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/video/camera/DeviceOrientationManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/video/camera/DeviceOrientationManager.java
@@ -68,10 +68,29 @@ public class DeviceOrientationManager {
   }
 
 
-  /** @return the last received UI orientation. */
-  @Nullable
+  /**
+   * @return the last received UI orientation, or the current UI orientation computed on demand
+   *     when no orientation change has been received yet.
+   *
+   * <p>{@code start()} is intentionally never called from {@link
+   * com.cloudwebrtc.webrtc.video.camera.CameraUtils} (see the TODO in its constructor), so {@code
+   * lastOrientation} stays {@code null} forever and {@code setFocusPoint}/{@code setExposurePoint}
+   * crashed with a {@code NullPointerException} inside {@code convertPointToMeteringRectangle}
+   * ({@code Enum.ordinal()} on the {@code @NonNull} orientation parameter). Computing the current
+   * orientation on demand fixes tap-to-focus without re-introducing the receiver-registration
+   * problem that {@code start()} was disabled for. {@code PORTRAIT_UP} is only used when no
+   * Activity is attached (backgrounded/terminated), matching the default of {@code
+   * getUIOrientation()}.
+   */
+  @NonNull
   public PlatformChannel.DeviceOrientation getLastUIOrientation() {
-    return this.lastOrientation;
+    if (this.lastOrientation != null) {
+      return this.lastOrientation;
+    }
+    if (this.activity == null) {
+      return PlatformChannel.DeviceOrientation.PORTRAIT_UP;
+    }
+    return getUIOrientation();
   }
 
   /**


### PR DESCRIPTION
## Description

On Android, every `Helper.setFocusPoint` / `Helper.setExposurePoint` call crashes inside the plugin with:

```
E MethodChannel#FlutterWebRTC.Method: Failed to handle method call
E MethodChannel#FlutterWebRTC.Method: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.Enum.ordinal()' on a null object reference
	at com.cloudwebrtc.webrtc.video.camera.CameraUtils.convertPointToMeteringRectangle
	at com.cloudwebrtc.webrtc.video.camera.CameraUtils.setFocusPoint
	at com.cloudwebrtc.webrtc.MethodCallHandlerImpl.onMethodCall
```

This makes tap-to-focus / tap-to-expose completely non-functional on Android. It is hit in the wild by anything wiring viewfinder taps to these helpers — e.g. LiveKit's `VideoTrackRenderer.onViewFinderTap` calls both on every tap.

## Root cause

`CameraUtils`'s constructor intentionally never calls `deviceOrientationManager.start()` (see the existing `TODO: get a proper fix at some point` comment — registering the receiver broke terminated-app scenarios). With the receiver never started, `DeviceOrientationManager.getLastUIOrientation()` returns its `lastOrientation` cache, which stays `null` forever.

`setFocusPoint`/`setExposurePoint` then pass that `null` straight into `convertPointToMeteringRectangle(..., @NonNull DeviceOrientation orientation)`, which calls `orientation.ordinal()` → guaranteed NPE on every call.

## Fix

Fix at the source instead of null-guarding every caller: when the cache is empty, `getLastUIOrientation()` now computes the *actual* current UI orientation on demand via the already-existing `getUIOrientation()` (real display rotation + configuration), falling back to `PORTRAIT_UP` only when no `Activity` is attached (backgrounded/terminated) — the same default `getUIOrientation()` itself uses for undefined configurations.

- No behaviour change for code paths where orientation change events populate the cache (if `start()` is ever re-enabled).
- Does not re-introduce the receiver-registration problem `start()` was disabled for.
- The method's contract tightens from `@Nullable` to `@NonNull`; its only callers (`setFocusPoint`, `setExposurePoint`) already required non-null.

## Testing

Reproduced on a physical Android device (MediaTek, Android 11) via LiveKit `VideoTrackRenderer` viewfinder taps: before the patch every tap logged the NPE above and focus never moved; with the patch applied (pinned fork) taps produce metering rectangles and no exceptions.
