### PR TITLE
fix: serialize data channel event queue access across threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 [Unreleased]
 
+* [Darwin/Android] fix: serialize data channel `eventSink`/`eventQueue` access between the WebRTC signaling thread and the platform thread. On iOS the unsynchronized access could crash with `EXC_BAD_ACCESS` in `objc_retain` inside `-[RTCDataChannel(Flutter) onListenWithArguments:eventSink:]`.
 * [Darwin] feat: expose the audio device module's microphone mute mode (`Helper.setMicrophoneMuteMode` / `Helper.getMicrophoneMuteMode`). `voiceProcessing` (the default) plays the platform mute tone on mute/unmute; `inputMixer` and `restartEngine` mute silently (#2098).
 * [Darwin/Android] feat: add ADM-level microphone mute (`Helper.setMicrophoneMuted` / `Helper.isMicrophoneMuted`), independent of `MediaStreamTrack.enabled`.
 

--- a/android/src/main/java/com/cloudwebrtc/webrtc/DataChannelObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/DataChannelObserver.java
@@ -20,6 +20,7 @@ class DataChannelObserver implements DataChannel.Observer, EventChannel.StreamHa
     private final EventChannel eventChannel;
     private EventChannel.EventSink eventSink;
     private final ArrayList eventQueue = new ArrayList();
+    private final Object eventLock = new Object();
 
     DataChannelObserver(BinaryMessenger messenger, String peerConnectionId, String flutterId,
                         DataChannel dataChannel) {
@@ -46,16 +47,20 @@ class DataChannelObserver implements DataChannel.Observer, EventChannel.StreamHa
 
     @Override
     public void onListen(Object o, EventChannel.EventSink sink) {
-        eventSink = new AnyThreadSink(sink);
-        for(Object event : eventQueue) {
-            eventSink.success(event);
+        synchronized (eventLock) {
+            eventSink = new AnyThreadSink(sink);
+            for (Object event : eventQueue) {
+                eventSink.success(event);
+            }
+            eventQueue.clear();
         }
-        eventQueue.clear();
     }
 
     @Override
     public void onCancel(Object o) {
-        eventSink = null;
+        synchronized (eventLock) {
+            eventSink = null;
+        }
     }
     
     @Override
@@ -103,10 +108,12 @@ class DataChannelObserver implements DataChannel.Observer, EventChannel.StreamHa
     }
 
     private void sendEvent(ConstraintsMap params) {
-        if (eventSink != null) {
-            eventSink.success(params.toMap());
-        } else {
-            eventQueue.add(params.toMap());
+        synchronized (eventLock) {
+            if (eventSink != null) {
+                eventSink.success(params.toMap());
+            } else {
+                eventQueue.add(params.toMap());
+            }
         }
     }
 }

--- a/common/darwin/Classes/FlutterRTCDataChannel.m
+++ b/common/darwin/Classes/FlutterRTCDataChannel.m
@@ -53,19 +53,21 @@
 #pragma mark - FlutterStreamHandler methods
 
 - (FlutterError* _Nullable)onCancelWithArguments:(id _Nullable)arguments {
-  self.eventSink = nil;
+  @synchronized(self) {
+    self.eventSink = nil;
+  }
   return nil;
 }
 
 - (FlutterError* _Nullable)onListenWithArguments:(id _Nullable)arguments
                                        eventSink:(nonnull FlutterEventSink)sink {
-  self.eventSink = sink;
-  NSEnumerator* enumerator = [self.eventQueue objectEnumerator];
-  id event;
-  while ((event = enumerator.nextObject) != nil) {
-    postEvent(sink, event);
-  };
-  self.eventQueue = nil;
+  @synchronized(self) {
+    self.eventSink = sink;
+    for (id event in self.eventQueue) {
+      postEvent(sink, event);
+    }
+    self.eventQueue = nil;
+  }
   return nil;
 }
 @end
@@ -85,8 +87,8 @@
     NSString* flutterId = [[NSUUID UUID] UUIDString];
     peerConnection.dataChannels[flutterId] = dataChannel;
     dataChannel.flutterChannelId = flutterId;
-    dataChannel.delegate = self;
     dataChannel.eventQueue = nil;
+    dataChannel.delegate = self;
 
     FlutterEventChannel* eventChannel = [FlutterEventChannel
         eventChannelWithName:[NSString stringWithFormat:@"FlutterWebRTC/dataChannelEvent%1$@%2$@",
@@ -163,13 +165,14 @@
 }
 
 - (void)sendEvent:(id)event withChannel:(RTCDataChannel*)channel {
-  if (channel.eventSink) {
-    postEvent(channel.eventSink, event);
-  } else {
-    if (!channel.eventQueue) {
-      channel.eventQueue = [NSMutableArray array];
+  @synchronized(channel) {
+    FlutterEventSink eventSink = channel.eventSink;
+    if (eventSink) {
+      postEvent(eventSink, event);
+    } else {
+      NSArray<id>* eventQueue = channel.eventQueue;
+      channel.eventQueue = eventQueue ? [eventQueue arrayByAddingObject:event] : @[ event ];
     }
-    channel.eventQueue = [channel.eventQueue arrayByAddingObject:event];
   }
 }
 

--- a/common/darwin/Classes/FlutterRTCPeerConnection.m
+++ b/common/darwin/Classes/FlutterRTCPeerConnection.m
@@ -574,6 +574,7 @@
   NSString* flutterChannelId = [[NSUUID UUID] UUIDString];
   NSNumber* dataChannelId = [NSNumber numberWithInteger:dataChannel.channelId];
   dataChannel.peerConnectionId = peerConnection.flutterId;
+  dataChannel.eventQueue = nil;
   dataChannel.delegate = self;
   peerConnection.dataChannels[flutterChannelId] = dataChannel;
 
@@ -584,7 +585,6 @@
 
   dataChannel.eventChannel = eventChannel;
   dataChannel.flutterChannelId = flutterChannelId;
-  dataChannel.eventQueue = nil;
 
   dispatch_async(dispatch_get_main_queue(), ^{
     // setStreamHandler on main thread


### PR DESCRIPTION
Fixes #2117

The data channel's `eventSink` and `eventQueue` are written from the WebRTC signaling thread in `sendEvent` and read from the platform thread in `onListen`/`onCancel`, with no synchronization. On Darwin that can hand `onListen` an array the signaling thread has just deallocated, crashing in `objc_retain`; on Android it can throw `ConcurrentModificationException` out of `onListen` and drop the queued events. See the issue for the crash report and the full analysis.

### The fix

Guard every access with a per-channel lock — `@synchronized(channel)` on Darwin, a lock object on Android — and drain the queue while the lock is held on both platforms.

Draining inside the lock costs nothing, because delivery never blocks: `postEvent` only dispatches to the main queue on Darwin, and `AnyThreadSink` posts to the main looper on Android. It is also what keeps the queued events ahead of anything the signaling thread sends concurrently, without relying on which thread happens to deliver them.

Neither critical section acquires a second lock, so no lock-order inversion is possible, and both hold the lock only for a pointer swap plus a non-blocking dispatch.

`createDataChannel` resets `eventQueue` *after* attaching the delegate, so an event the signaling thread queues in between is silently dropped — defeating the purpose of the queue — and the reset itself races with the signaling thread's write. The reset now happens before the delegate is set. `didOpenDataChannel` already runs on the signaling thread and is not affected; it is reordered the same way only so both creation paths read alike.

Every access to these two associated objects is now either inside the lock or before the delegate is attached, when no other thread can reach the channel yet.

Two more instances of the same class of race are deliberately left alone here, both in `FlutterRTCPeerConnection.m`:

* `peerConnection.eventSink` — written on the platform thread, read from the signaling thread in 15 places.
* `peerConnection.dataChannels` — an `NSMutableDictionary` written from the signaling thread in `didOpenDataChannel`, while the platform thread reads and mutates it in `createDataChannel`, `dataChannelClose`, `dataChannelSend` and others.

Both are written once per connection or per channel rather than once per event, so they are far less exposed than the queue, and both reach well beyond the call sites touched here. Folding them in would make this change much harder to review; they are better addressed on their own.

### Testing

* `flutter analyze` and `flutter test` on the plugin: clean.
* `example` built for Android and macOS against this branch (macOS compiles the same `common/darwin` sources as iOS).
* `example`'s `DataChannelLoopBackSample` run on macOS with the patch: channels open, messages flow both ways, and repeated connect/hang-up cycles behave as before.
* An app using `livekit_client` built for both iOS and Android with the patch applied.
* `git clang-format --diff` reports no violations on the changed lines.
