### PR TITLE
fix(iOS): remove private buttonPressed: broadcast picker selector

### DIFF
--- a/common/darwin/Classes/FlutterRTCDesktopCapturer.m
+++ b/common/darwin/Classes/FlutterRTCDesktopCapturer.m
@@ -1,9 +1,8 @@
-#import <objc/runtime.h>
-
 #import "FlutterRTCDesktopCapturer.h"
 
 #if TARGET_OS_IPHONE
 #import <ReplayKit/ReplayKit.h>
+#import <UIKit/UIKit.h>
 #import "FlutterBroadcastScreenCapturer.h"
 #import "FlutterRPScreenRecorder.h"
 #endif
@@ -71,9 +70,18 @@ NSArray<RTCDesktopSource*>* _captureSources;
     } else {
       NSLog(@"Not able to find the %@ key", kRTCScreenSharingExtension);
     }
-    SEL selector = NSSelectorFromString(@"buttonPressed:");
-    if ([picker respondsToSelector:selector]) {
-      [picker performSelector:selector withObject:nil];
+    UIButton* button = nil;
+    for (UIView* subview in picker.subviews) {
+      if ([subview isKindOfClass:[UIButton class]]) {
+        button = (UIButton*)subview;
+        break;
+      }
+    }
+
+    if (button != nil) {
+      [button sendActionsForControlEvents:UIControlEventTouchUpInside];
+    } else {
+      NSLog(@"Unable to find button in RPSystemBroadcastPickerView");
     }
   }
 #endif


### PR DESCRIPTION
## Summary

Apple's automated App Store review rejects iOS binaries containing the non-public `RPSystemBroadcastPickerView.buttonPressed:` selector.

This replaces the private selector invocation with public UIKit APIs by locating the picker's `UIButton` subview and sending the `UIControlEventTouchUpInside` control event.

The automatic broadcast picker path is preserved. The existing `broadcast-manual` behavior and remaining screen-capture implementation are unchanged.

This follows the public-button approach adopted by LiveKit in:
https://github.com/livekit/client-sdk-swift/pull/1065

Fixes #2120.

## Changes

- Remove the `NSSelectorFromString(@"buttonPressed:")` invocation.
- Trigger the picker through `UIButton` and `UIControlEventTouchUpInside`.
- Log a warning if the picker button cannot be found.
- Remove the unused Objective-C runtime import.
- Import UIKit explicitly.

## Verification

- `flutter analyze`
- `flutter test`
- `flutter build ios --release --no-codesign`
- Confirmed `buttonPressed:` is absent from tracked source.
- Confirmed `buttonPressed:` is absent from every Mach-O file in the compiled iOS application.

Physical broadcast-picker activation was not tested locally.

## Scope

## Summary

Apple's automated App Store review rejects iOS binaries containing the non-public `RPSystemBroadcastPickerView.buttonPressed:` selector.

This replaces the private selector invocation with public UIKit APIs by locating the picker's `UIButton` subview and sending the `UIControlEventTouchUpInside` control event.

The automatic broadcast picker path is preserved. The existing `broadcast-manual` behavior and remaining screen-capture implementation are unchanged.

This follows the public-button approach adopted by LiveKit in:
https://github.com/livekit/client-sdk-swift/pull/1065

Fixes #2120.

## Changes

- Remove the `NSSelectorFromString(@"buttonPressed:")` invocation.
- Trigger the picker through `UIButton` and `UIControlEventTouchUpInside`.
- Log a warning if the picker button cannot be found.
- Remove the unused Objective-C runtime import.
- Import UIKit explicitly.

## Verification

- `flutter analyze`
- `flutter test`
- `flutter build ios --release --no-codesign`
- Confirmed `buttonPressed:` is absent from tracked source.
- Confirmed `buttonPressed:` is absent from every Mach-O file in the compiled iOS application.

Physical broadcast-picker activation was not tested locally.

## Scope

This intentionally retains `RPSystemBroadcastPickerView` for compatibility with iOS 26 and earlier. Migration to ScreenCaptureKit on iOS 27 and later is outside the scope of this focused fix.