### PR TITLE
release: 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 
 # Changelog
 
-[Unreleased]
+[1.6.0] - 2026-07-29
 
 * [Darwin] feat: Swift Package Manager support. Apps with Flutter's SPM integration enabled consume the plugin as a Swift package automatically; CocoaPods remains fully supported (#2062).
-* [Darwin/Android] fix: serialize data channel `eventSink`/`eventQueue` access between the WebRTC signaling thread and the platform thread. On iOS the unsynchronized access could crash with `EXC_BAD_ACCESS` in `objc_retain` inside `-[RTCDataChannel(Flutter) onListenWithArguments:eventSink:]`.
-* [Darwin] feat: expose the audio device module's microphone mute mode (`Helper.setMicrophoneMuteMode` / `Helper.getMicrophoneMuteMode`). `voiceProcessing` (the default) plays the platform mute tone on mute/unmute; `inputMixer` and `restartEngine` mute silently (#2098).
-* [Darwin/Android] feat: add ADM-level microphone mute (`Helper.setMicrophoneMuted` / `Helper.isMicrophoneMuted`), independent of `MediaStreamTrack.enabled`.
+* [iOS] fix: replace the private `RPSystemBroadcastPickerView` `buttonPressed:` selector with public UIKit APIs, App Store review rejected binaries containing it (#2121).
+* [Darwin/Android] fix: serialize data channel `eventSink`/`eventQueue` access between the WebRTC signaling thread and the platform thread. On iOS the unsynchronized access could crash with `EXC_BAD_ACCESS` in `objc_retain` inside `-[RTCDataChannel(Flutter) onListenWithArguments:eventSink:]` (#2118).
+* [Darwin] feat: expose the audio device module's microphone mute mode (`Helper.setMicrophoneMuteMode` / `Helper.getMicrophoneMuteMode`). `voiceProcessing` (the default) plays the platform mute tone on mute/unmute; `inputMixer` and `restartEngine` mute silently (#2098, #2105).
+* [Darwin/Android] feat: add ADM-level microphone mute (`Helper.setMicrophoneMuted` / `Helper.isMicrophoneMuted`), independent of `MediaStreamTrack.enabled` (#2105).
+* [iOS/macOS] feat: `RTCVideoPlatformView.placeholderBuilder` to show a widget until the first frame renders (#2102).
+* [Android] feat: option to disable the built-in hardware AEC/NS (#2104).
+* [Android] feat: expose `getStreamForId` to embedders (#2109).
+* [Android] fix: stop-time deadlock/ANR in `OrientationAwareScreenCapturer` (#2092).
+* [Android] fix: NPE in `setFocusPoint`/`setExposurePoint` when the orientation cache was never populated (#2113).
+* [Darwin] fix: create the parent directory before `captureFrame` writes the image file (#2090).
 
 [1.5.2] - 2026-06-20
 

--- a/ios/flutter_webrtc.podspec
+++ b/ios/flutter_webrtc.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_webrtc'
-  s.version          = '1.5.2'
+  s.version          = '1.6.0'
   s.summary          = 'Flutter WebRTC plugin for iOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/macos/flutter_webrtc.podspec
+++ b/macos/flutter_webrtc.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_webrtc'
-  s.version          = '1.5.2'
+  s.version          = '1.6.0'
   s.summary          = 'Flutter WebRTC plugin for macOS.'
   s.description      = <<-DESC
 A new flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_webrtc
 description: Flutter WebRTC plugin for iOS/Android/Desktop/Web, based on GoogleWebRTC.
-version: 1.5.2
+version: 1.6.0
 homepage: https://github.com/cloudwebrtc/flutter-webrtc
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
Promotes [Unreleased] to 1.6.0 and bumps pubspec plus both podspecs.

Highlights:

- Swift Package Manager support for iOS and macOS, CocoaPods remains fully supported (#2062)
- App Store rejection fix, the private broadcast picker selector is replaced with public API (#2121)
- Microphone mute mode and ADM level mute APIs (#2105)
- Data channel event queue thread safety fix (#2118)
- Screen capture stop deadlock/ANR fix on Android (#2092)

Also backfills changelog entries for #2102, #2104, #2109, #2113, #2090 which were missing from [Unreleased].