### PR TITLE
fix(android): refresh remote video tracks after renegotiation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -78,4 +78,5 @@ dependencies {
     implementation 'io.github.webrtc-sdk:android:144.7559.09'
     implementation 'com.github.davidliu:audioswitch:039a35aefab7747c557242fa216c9ea11743b604'
     implementation 'androidx.annotation:annotation:1.1.0'
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/FlutterRTCVideoRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/FlutterRTCVideoRenderer.java
@@ -23,12 +23,12 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
     private static final String TAG = FlutterWebRTCPlugin.TAG;
     private final TextureRegistry.SurfaceProducer producer;
     private int id = -1;
-    private MediaStream mediaStream;
+    private String mediaStreamId;
 
     private String ownerTag;
 
     public void Dispose() {
-        //destroy
+        setVideoTrack(null);
         if (surfaceTextureRenderer != null) {
             surfaceTextureRenderer.release();
         }
@@ -96,6 +96,7 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
      * The {@code VideoTrack}, if any, rendered by this {@code FlutterRTCVideoRenderer}.
      */
     private VideoTrack videoTrack;
+    private String videoTrackId;
 
     EventChannel eventChannel;
     EventChannel.EventSink eventSink;
@@ -134,7 +135,14 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
      * resources (if rendering is in progress).
      */
     private void removeRendererFromVideoTrack() {
-        videoTrack.removeSink(surfaceTextureRenderer);
+        if (videoTrack == null) {
+            return;
+        }
+        try {
+            videoTrack.removeSink(surfaceTextureRenderer);
+        } catch (IllegalStateException e) {
+            Log.w(TAG, "VideoTrack was disposed before its renderer was removed");
+        }
     }
 
     /**
@@ -147,7 +155,7 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
      */
     public void setStream(MediaStream mediaStream, String ownerTag) {
         VideoTrack videoTrack;
-        this.mediaStream = mediaStream;
+        this.mediaStreamId = mediaStream == null ? null : mediaStream.getId();
         this.ownerTag = ownerTag;
         if (mediaStream == null) {
             videoTrack = null;
@@ -171,7 +179,7 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
      */
     public void setStream(MediaStream mediaStream,String trackId, String ownerTag) {
         VideoTrack videoTrack;
-        this.mediaStream = mediaStream;
+        this.mediaStreamId = mediaStream == null ? null : mediaStream.getId();
         this.ownerTag = ownerTag;
         if (mediaStream == null) {
             videoTrack = null;
@@ -191,6 +199,20 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
     }
 
     /**
+     * Sets a video track already resolved from its owning PeerConnection.
+     *
+     * The stream id is retained only for renderer lifecycle bookkeeping. The
+     * MediaStream wrapper itself may be replaced or disposed by a Unified Plan
+     * renegotiation while the logical stream and track ids remain unchanged.
+     */
+    public void setTrack(
+            VideoTrack videoTrack, String mediaStreamId, String ownerTag) {
+        this.mediaStreamId = mediaStreamId;
+        this.ownerTag = ownerTag;
+        setVideoTrack(videoTrack);
+    }
+
+    /**
      * Sets the {@code VideoTrack} to be rendered by this {@code FlutterRTCVideoRenderer}.
      *
      * @param videoTrack The {@code VideoTrack} to be rendered by this
@@ -205,6 +227,7 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
             }
 
             this.videoTrack = videoTrack;
+            this.videoTrackId = videoTrack == null ? null : videoTrack.id();
 
             if (videoTrack != null) {
                 try {
@@ -244,16 +267,16 @@ public class FlutterRTCVideoRenderer implements EventChannel.StreamHandler {
     }
 
     public boolean checkMediaStream(String id, String ownerTag) {
-        if (null == id || null == mediaStream || ownerTag == null || !ownerTag.equals(this.ownerTag)) {
+        if (null == id || null == mediaStreamId || ownerTag == null || !ownerTag.equals(this.ownerTag)) {
             return false;
         }
-        return id.equals(mediaStream.getId());
+        return id.equals(mediaStreamId);
     }
 
     public boolean checkVideoTrack(String id, String ownerTag) {
-        if (null == id || null == videoTrack  || ownerTag == null || !ownerTag.equals(this.ownerTag)) {
+        if (null == id || null == videoTrackId || ownerTag == null || !ownerTag.equals(this.ownerTag)) {
             return false;
         }
-        return id.equals(videoTrack.id());
+        return id.equals(videoTrackId);
     }
 }

--- a/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/MethodCallHandlerImpl.java
@@ -742,7 +742,12 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
           stream = getStreamForId(streamId, ownerTag);
         }
         if (trackId != null && !trackId.equals("0")){
-          render.setStream(stream, trackId, ownerTag);
+          MediaStreamTrack track = getTrackForId(trackId, ownerTag);
+          if (track instanceof VideoTrack) {
+            render.setTrack((VideoTrack) track, streamId, ownerTag);
+          } else {
+            render.setStream(stream, trackId, ownerTag);
+          }
         } else {
           render.setStream(stream, ownerTag);
         }
@@ -1556,10 +1561,27 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
     }
   }
 
+  @Override
+  public void onRemoteTrackAdded(
+      String peerConnectionId, String streamId, MediaStreamTrack track) {
+    if (!(track instanceof VideoTrack)) {
+      return;
+    }
+    final String trackId = track.id();
+    mainHandler.post(() -> {
+      for (int i = 0; i < renders.size(); i++) {
+        FlutterRTCVideoRenderer renderer = renders.valueAt(i);
+        if (renderer.checkVideoTrack(trackId, peerConnectionId)) {
+          renderer.setTrack((VideoTrack) track, streamId, peerConnectionId);
+        }
+      }
+    });
+  }
+
   public MediaStreamTrack getRemoteTrack(String trackId) {
     for (Entry<String, PeerConnectionObserver> entry : mPeerConnectionObservers.entrySet()) {
       PeerConnectionObserver pco = entry.getValue();
-      MediaStreamTrack track = pco.remoteTracks.get(trackId);
+      MediaStreamTrack track = pco.getRemoteTrack(trackId);
       if (track == null) {
         track = pco.getTransceiversTrack(trackId);
       }
@@ -1660,7 +1682,7 @@ public class MethodCallHandlerImpl implements MethodCallHandler, StateProvider {
           continue;
 
         PeerConnectionObserver pco = entry.getValue();
-        mediaStreamTrack = pco.remoteTracks.get(trackId);
+        mediaStreamTrack = pco.getRemoteTrack(trackId);
 
         if (mediaStreamTrack == null) {
           mediaStreamTrack = pco.getTransceiversTrack(trackId);

--- a/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/PeerConnectionObserver.java
@@ -54,7 +54,8 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
   private PeerConnection peerConnection;
   private final PeerConnection.RTCConfiguration configuration;
   final Map<String, MediaStream> remoteStreams = new HashMap<>();
-  final Map<String, MediaStreamTrack> remoteTracks = new HashMap<>();
+  private final RemoteTrackRegistry<MediaStreamTrack> remoteTracks =
+      new RemoteTrackRegistry<>();
   final Map<String, RtpTransceiver> transceivers = new HashMap<>();
   private final StateProvider stateProvider;
   private final EventChannel eventChannel;
@@ -417,6 +418,7 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
       String trackId = track.id();
 
       remoteTracks.put(trackId, track);
+      stateProvider.onRemoteTrackAdded(id, streamId, track);
 
       ConstraintsMap trackInfo = new ConstraintsMap();
       trackInfo.putString("id", trackId);
@@ -432,6 +434,7 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
       String trackId = track.id();
 
       remoteTracks.put(trackId, track);
+      stateProvider.onRemoteTrackAdded(id, streamId, track);
 
       ConstraintsMap trackInfo = new ConstraintsMap();
       trackInfo.putString("id", trackId);
@@ -460,10 +463,10 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
     String streamId = mediaStream.getId();
 
     for (VideoTrack track : mediaStream.videoTracks) {
-      this.remoteTracks.remove(track.id());
+      this.remoteTracks.remove(track.id(), track);
     }
     for (AudioTrack track : mediaStream.audioTracks) {
-      this.remoteTracks.remove(track.id());
+      this.remoteTracks.remove(track.id(), track);
     }
 
     ConstraintsMap params = new ConstraintsMap();
@@ -1219,13 +1222,18 @@ class PeerConnectionObserver implements PeerConnection.Observer, EventChannel.St
     for (RtpTransceiver transceiver : transceivers) {
       RtpReceiver receiver = transceiver.getReceiver();
       if (receiver != null) {
-        if (receiver.track() != null && receiver.track().id().equals(trackId)) {
-          track = receiver.track();
+        MediaStreamTrack receiverTrack = receiver.track();
+        if (receiverTrack != null && receiverTrack.id().equals(trackId)) {
+          track = receiverTrack;
           break;
         }
       }
     }
     return track;
+  }
+
+  MediaStreamTrack getRemoteTrack(String trackId) {
+    return remoteTracks.get(trackId);
   }
 
   public String getNextDataChannelUUID() {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/RemoteTrackRegistry.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/RemoteTrackRegistry.java
@@ -1,0 +1,35 @@
+package com.cloudwebrtc.webrtc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Thread-safe registry of the current remote track object for each track id.
+ *
+ * A Unified Plan renegotiation may replace the Java track wrapper while
+ * preserving its WebRTC track id. Late removal of the previous MediaStream
+ * must not remove the replacement from the registry.
+ */
+final class RemoteTrackRegistry<T> {
+  private final Map<String, T> tracks = new HashMap<>();
+
+  synchronized void put(String trackId, T track) {
+    tracks.put(trackId, track);
+  }
+
+  synchronized T get(String trackId) {
+    return tracks.get(trackId);
+  }
+
+  synchronized boolean remove(String trackId, T track) {
+    if (tracks.get(trackId) != track) {
+      return false;
+    }
+    tracks.remove(trackId);
+    return true;
+  }
+
+  synchronized void clear() {
+    tracks.clear();
+  }
+}

--- a/android/src/main/java/com/cloudwebrtc/webrtc/StateProvider.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/StateProvider.java
@@ -24,6 +24,9 @@ public interface StateProvider {
 
   LocalTrack getLocalTrack(String trackId);
 
+  void onRemoteTrackAdded(
+      String peerConnectionId, String streamId, MediaStreamTrack track);
+
   String getNextStreamUUID();
 
   String getNextTrackUUID();

--- a/android/src/test/java/com/cloudwebrtc/webrtc/RemoteTrackRegistryTest.java
+++ b/android/src/test/java/com/cloudwebrtc/webrtc/RemoteTrackRegistryTest.java
@@ -1,0 +1,23 @@
+package com.cloudwebrtc.webrtc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RemoteTrackRegistryTest {
+  @Test
+  public void keepsReplacementWhenPreviousTrackIsRemovedLate() {
+    RemoteTrackRegistry<Object> registry = new RemoteTrackRegistry<>();
+    Object previousTrack = new Object();
+    Object replacementTrack = new Object();
+
+    registry.put("video", previousTrack);
+    registry.put("video", replacementTrack);
+
+    assertFalse(registry.remove("video", previousTrack));
+    assertSame(replacementTrack, registry.get("video"));
+    assertTrue(registry.remove("video", replacementTrack));
+  }
+}


### PR DESCRIPTION
Fixes #2124

## Summary

Fixes an Android video rendering issue observed when connecting to Cloudflare Realtime Serverless SFU.

After the SFU subscription renegotiation completed successfully, the remote video remained black and `RTCVideoView` never rendered its first frame, even though inbound RTP statistics showed that video frames were being received and decoded.

## Root cause

During a Unified Plan renegotiation, a new Java `MediaStream`/`VideoTrack` wrapper can be exposed while preserving the same logical WebRTC track ID.

The Android renderer remained attached to the previous `VideoTrack` object. As a result, the active remote track received decoded frames while the `VideoSink` used by `FlutterRTCVideoRenderer` was still connected to the stale track wrapper.

A late removal of the previous stream could also remove the replacement track from the track lookup because both objects shared the same track ID.

## Solution

This change:

- introduces a thread-safe registry containing the current remote track object for each track ID;
- updates the registry whenever a remote stream exposes a replacement track;
- automatically rebinds matching Android video renderers on the main thread;
- removes tracks using object identity, preventing a late removal event for an old wrapper from removing its replacement;
- allows the renderer to bind directly to the resolved `VideoTrack`;
- stores stream and track IDs for lifecycle bookkeeping instead of retaining potentially disposed `MediaStream` wrappers;
- safely detaches the previous `VideoSink` during track replacement and renderer disposal.

## Result

After renegotiation, the renderer is automatically moved to the current remote `VideoTrack`. The first frame is rendered correctly and the video continues playing instead of leaving a black `RTCVideoView`.

## Tests

- Added a unit test covering replacement tracks with the same ID and late removal of the previous track object.
- Android `testDebugUnitTest` passes.
- Dart formatting and Flutter analysis pass.
- Flutter tests pass.
- Repeated manual connections through Cloudflare Realtime Serverless SFU render video correctly and complete teardown without exceptions.
