### PR TITLE
fix(linux): marshal MethodResultProxy callbacks to platform thread

### DIFF
--- a/common/cpp/include/flutter_common.h
+++ b/common/cpp/include/flutter_common.h
@@ -150,7 +150,8 @@ class MethodCallProxy {
 class MethodResultProxy {
  public:
   static std::unique_ptr<MethodResultProxy> Create(
-      std::unique_ptr<MethodResult> method_result);
+      std::unique_ptr<MethodResult> method_result,
+      TaskRunner* task_runner = nullptr);
 
   virtual ~MethodResultProxy() = default;
 

--- a/common/cpp/src/flutter_common.cc
+++ b/common/cpp/src/flutter_common.cc
@@ -32,40 +32,84 @@ std::unique_ptr<MethodCallProxy> MethodCallProxy::Create(
 
 class MethodResultProxyImpl : public MethodResultProxy {
  public:
-  explicit MethodResultProxyImpl(std::unique_ptr<MethodResult> method_result)
-      : method_result_(std::move(method_result)) {}
+  MethodResultProxyImpl(std::unique_ptr<MethodResult> method_result,
+                        TaskRunner* task_runner)
+      : method_result_(std::move(method_result)), task_runner_(task_runner) {}
   ~MethodResultProxyImpl() {}
 
-  // Reports success with no result.
-  void Success() override { method_result_->Success(); }
-
-  // Reports success with a result.
-  void Success(const EncodableValue& result) override {
-    method_result_->Success(result);
+  void Success() override {
+    if (!method_result_)
+      return;
+    if (task_runner_) {
+      std::shared_ptr<MethodResult> result(std::move(method_result_));
+      task_runner_->EnqueueTask([result]() { result->Success(); });
+    } else {
+      method_result_->Success();
+    }
   }
 
-  // Reports an error.
+  void Success(const EncodableValue& val) override {
+    if (!method_result_)
+      return;
+    if (task_runner_) {
+      std::shared_ptr<MethodResult> result(std::move(method_result_));
+      task_runner_->EnqueueTask([result, val]() { result->Success(val); });
+    } else {
+      method_result_->Success(val);
+    }
+  }
+
   void Error(const std::string& error_code,
              const std::string& error_message,
              const EncodableValue& error_details) override {
-    method_result_->Error(error_code, error_message, error_details);
+    if (!method_result_)
+      return;
+    if (task_runner_) {
+      std::shared_ptr<MethodResult> result(std::move(method_result_));
+      task_runner_->EnqueueTask(
+          [result, error_code, error_message, error_details]() {
+            result->Error(error_code, error_message, error_details);
+          });
+    } else {
+      method_result_->Error(error_code, error_message, error_details);
+    }
   }
 
-  // Reports an error with a default error code and no details.
   void Error(const std::string& error_code,
              const std::string& error_message = "") override {
-    method_result_->Error(error_code, error_message);
+    if (!method_result_)
+      return;
+    if (task_runner_) {
+      std::shared_ptr<MethodResult> result(std::move(method_result_));
+      task_runner_->EnqueueTask([result, error_code, error_message]() {
+        result->Error(error_code, error_message);
+      });
+    } else {
+      method_result_->Error(error_code, error_message);
+    }
   }
 
-  void NotImplemented() override { method_result_->NotImplemented(); }
+  void NotImplemented() override {
+    if (!method_result_)
+      return;
+    if (task_runner_) {
+      std::shared_ptr<MethodResult> result(std::move(method_result_));
+      task_runner_->EnqueueTask([result]() { result->NotImplemented(); });
+    } else {
+      method_result_->NotImplemented();
+    }
+  }
 
  private:
   std::unique_ptr<MethodResult> method_result_;
+  TaskRunner* task_runner_;
 };
 
 std::unique_ptr<MethodResultProxy> MethodResultProxy::Create(
-    std::unique_ptr<MethodResult> method_result) {
-  return std::make_unique<MethodResultProxyImpl>(std::move(method_result));
+    std::unique_ptr<MethodResult> method_result,
+    TaskRunner* task_runner) {
+  return std::make_unique<MethodResultProxyImpl>(std::move(method_result),
+                                                 task_runner);
 }
 
 class EventChannelProxyImpl : public EventChannelProxy {

--- a/linux/flutter_webrtc_plugin.cc
+++ b/linux/flutter_webrtc_plugin.cc
@@ -57,8 +57,9 @@ class FlutterWebRTCPluginImpl : public FlutterWebRTCPlugin {
                         std::unique_ptr<MethodResult> result) {
     // handle method call and forward to webrtc native sdk.
     auto method_call_proxy = MethodCallProxy::Create(method_call);
-    webrtc_->HandleMethodCall(*method_call_proxy.get(),
-                              MethodResultProxy::Create(std::move(result)));
+    webrtc_->HandleMethodCall(
+        *method_call_proxy.get(),
+        MethodResultProxy::Create(std::move(result), task_runner()));
   }
 
  private:


### PR DESCRIPTION
fix(linux): marshal MethodResultProxy callbacks to platform thread (#2126)

**Problem**

libwebrtc invokes PeerConnection callbacks (`setRemoteDescription`,
`createAnswer`, etc.) on worker threads. `MethodResultProxyImpl` forwarded
these directly to Flutter's `MethodResult`, which on Linux/GTK silently
drops responses that arrive on a non-platform thread. As a result the Dart
`Future` for the operation never resolved, so subscriber SDP renegotiation
never completed — `livekit_client` never sent the SDP answer back to the
server and the peer connection stalled.

The sibling `EventChannelProxy` already solves this by marshalling through
`TaskRunner` (#1795 / `1c2ff6f`), but that marshalling was never extended to
`MethodResultProxy`.

**Fix**

Add an optional `TaskRunner*` parameter to `MethodResultProxy::Create`
(default `nullptr` so other platforms keep the current direct-call path).
When set, `Success`/`Error`/`NotImplemented` enqueue the call onto the
platform thread via `TaskRunner::EnqueueTask`. The `unique_ptr<MethodResult>`
is converted to `shared_ptr` for lambda capture (`std::function` requires
copyability), and a null guard guards against double-call since the proxy is
moved out on the first terminal call.

The Linux plugin passes its `task_runner()`; elinux and windows continue to
call `Create` without a runner (default `nullptr`).

### Testing

- `git clang-format` reports no violations on the changed lines (Chromium style).
- Validated in the originating Linux desktop application (Kohera, using
  `livekit_client`): subscriber SDP renegotiation completes and the answer is
  delivered where it previously hung on Linux/GTK.

Fixes #2126

Co-authored-by: Claude <noreply@anthropic.com>