### PR TITLE
fix: prevent event channel use-after-free on peer connection cleanup

### DIFF
--- a/common/cpp/src/flutter_common.cc
+++ b/common/cpp/src/flutter_common.cc
@@ -100,9 +100,9 @@ class EventChannelProxyImpl : public EventChannelProxy {
  
      channel_->SetStreamHandler(std::move(handler));
    }
- 
-   virtual ~EventChannelProxyImpl() {}
- 
+
+   virtual ~EventChannelProxyImpl() { channel_->SetStreamHandler(nullptr); }
+
    void Success(const EncodableValue& event, bool cache_event = true) override {
      if (on_listen_called_) {
        PostEvent(event);

--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -395,10 +395,6 @@ void FlutterPeerConnection::RTCPeerConnectionClose(
     base_->peerconnections_.erase(it2);
   }
 
-  auto it = base_->peerconnection_observers_.find(uuid);
-  if (it != base_->peerconnection_observers_.end())
-    base_->peerconnection_observers_.erase(it);
-
   result->Success();
 }
 
@@ -406,6 +402,10 @@ void FlutterPeerConnection::RTCPeerConnectionDispose(
     RTCPeerConnection* pc,
     const std::string& uuid,
     std::unique_ptr<MethodResultProxy> result) {
+  auto it = base_->peerconnection_observers_.find(uuid);
+  if (it != base_->peerconnection_observers_.end())
+    base_->peerconnection_observers_.erase(it);
+
   result->Success();
 }
 


### PR DESCRIPTION
fix: prevent event channel use-after-free on peer connection cleanup (#2127)

**Problem**

During peer connection teardown, `RTCPeerConnectionClose` erases the entry
from `peerconnection_observers_` immediately, but Dart's `RTCPeerConnection`
keeps its EventChannel subscription alive until `dispose()` (which invokes
`RTCPeerConnectionDispose`). Any event the WebRTC stack emits between `Close`
and `Dispose` therefore hits a destroyed observer — a use-after-free.

Additionally, `~EventChannelProxyImpl` was empty, so the stream handler could
remain registered after the proxy was destroyed, leaving dangling callbacks.

**Fix**

- Move the `peerconnection_observers_.erase(...)` from `RTCPeerConnectionClose`
  to `RTCPeerConnectionDispose`, so the event channel survives `Close` (until
  Dart has cancelled its subscription).
- In `~EventChannelProxyImpl`, call `channel_->SetStreamHandler(nullptr)` to
  drop the handler on destruction and prevent dangling callbacks.

### Testing

- `git clang-format` reports no violations on the changed lines (Chromium style).
- Validated in the originating Linux desktop application (Kohera, using
  `livekit_client`): rapid connect/hang-up cycles and swipe-kill teardown no
  longer crash on the event channel.

Fixes #2127

Co-authored-by: Claude <noreply@anthropic.com>