### PR TITLE
fix: skip unrecognized constraint value types in ParseConstraints

### DIFF
--- a/common/cpp/src/flutter_webrtc_base.cc
+++ b/common/cpp/src/flutter_webrtc_base.cc
@@ -149,7 +149,7 @@ void FlutterWebRTCBase::ParseConstraints(
       value = GetValue<bool>(v) ? RTCMediaConstraints::kValueTrue
                                 : RTCMediaConstraints::kValueFalse;
     } else {
-      value = std::to_string(GetValue<int>(v));
+      continue;
     }
     if (type == kMandatory) {
       mediaConstraints->AddMandatoryConstraint(key.c_str(), value.c_str());


### PR DESCRIPTION
fix: skip unrecognized constraint value types in ParseConstraints (#2128)

**Problem**

`FlutterWebRTCBase::ParseConstraints` throws `std::bad_variant_access` when a
constraint map entry holds a value type it does not explicitly handle (e.g. a
null / `std::monostate` `EncodableValue`). The final `else` branch
unconditionally calls `GetValue<int>(v)`:

```cpp
} else if (TypeIs<bool>(v)) {
  value = GetValue<bool>(v) ? RTCMediaConstraints::kValueTrue
                            : RTCMediaConstraints::kValueFalse;
} else {
  value = std::to_string(GetValue<int>(v));   // throws if v is not int
}
```

When `v` is null/`std::monostate` (passed by some callers for optional/empty
constraint fields), `GetValue<int>` throws, crashing the native side. This was
hit on the Linux desktop path during media/screen-capture constraint parsing.

**Fix**

Replace the final `else` branch with `continue;` so unrecognized value types
are skipped instead of forcing a `std::get<int>`:

```cpp
} else {
  continue;
}
```

Only recognized constraints are applied; parsing no longer crashes on empty or
unrecognized values.

### Testing

- `git clang-format` reports no violations on the changed line (Chromium style).
- Validated in the originating Linux desktop application (Kohera, using
  `livekit_client`): `getUserMedia`/`getDisplayMedia` with null/unrecognized
  constraint values no longer crashes the native side.

Fixes #2128

Co-authored-by: Claude <noreply@anthropic.com>