### PR TITLE
fix(linux): guard texture proxy and harden desktop source enumeration

### DIFF
--- a/common/cpp/src/flutter_screen_capture.cc
+++ b/common/cpp/src/flutter_screen_capture.cc
@@ -1,5 +1,7 @@
 #include "flutter_screen_capture.h"
 
+#include <stdexcept>
+
 namespace flutter_webrtc_plugin {
 
 FlutterScreenCapture::FlutterScreenCapture(FlutterWebRTCBase* base)
@@ -17,7 +19,6 @@ bool FlutterScreenCapture::BuildDesktopSourcesList(const EncodableList& types,
     } else if (type_str == "window") {
       desktop_type = DesktopType::kWindow;
     } else {
-      // std::cout << "Unknown type " << type_str << std::endl;
       return false;
     }
     scoped_refptr<RTCDesktopMediaList> source_list;
@@ -29,7 +30,15 @@ bool FlutterScreenCapture::BuildDesktopSourcesList(const EncodableList& types,
       source_list->RegisterMediaListObserver(this);
       medialist_[desktop_type] = source_list;
     }
-    source_list->UpdateSourceList(force_reload);
+#ifdef __linux__
+    try {
+      source_list->UpdateSourceList(force_reload, false);
+    } catch (...) {
+      continue;
+    }
+#else
+    source_list->UpdateSourceList(force_reload, false);
+#endif
     int count = source_list->GetSourceCount();
     for (int j = 0; j < count; j++) {
       sources_.push_back(source_list->GetSource(j));
@@ -61,7 +70,6 @@ void FlutterScreenCapture::GetDesktopSources(
     sources.push_back(EncodableValue(info));
   }
 
-  //std::cout << " sources: " << sources.size() << std::endl;
   auto map = EncodableMap();
   map[EncodableValue("sources")] = sources;
   result->Success(EncodableValue(map));
@@ -81,9 +89,6 @@ void FlutterScreenCapture::UpdateDesktopSources(
 
 void FlutterScreenCapture::OnMediaSourceAdded(
     scoped_refptr<MediaSource> source) {
-  std::cout << " OnMediaSourceAdded: " << source->id().std_string()
-            << std::endl;
-
   EncodableMap info;
   info[EncodableValue("event")] = "desktopSourceAdded";
   info[EncodableValue("id")] = EncodableValue(source->id().std_string());
@@ -100,9 +105,6 @@ void FlutterScreenCapture::OnMediaSourceAdded(
 
 void FlutterScreenCapture::OnMediaSourceRemoved(
     scoped_refptr<MediaSource> source) {
-  std::cout << " OnMediaSourceRemoved: " << source->id().std_string()
-            << std::endl;
-
   EncodableMap info;
   info[EncodableValue("event")] = "desktopSourceRemoved";
   info[EncodableValue("id")] = EncodableValue(source->id().std_string());
@@ -111,9 +113,6 @@ void FlutterScreenCapture::OnMediaSourceRemoved(
 
 void FlutterScreenCapture::OnMediaSourceNameChanged(
     scoped_refptr<MediaSource> source) {
-  std::cout << " OnMediaSourceNameChanged: " << source->id().std_string()
-            << std::endl;
-
   EncodableMap info;
   info[EncodableValue("event")] = "desktopSourceNameChanged";
   info[EncodableValue("id")] = EncodableValue(source->id().std_string());
@@ -123,9 +122,6 @@ void FlutterScreenCapture::OnMediaSourceNameChanged(
 
 void FlutterScreenCapture::OnMediaSourceThumbnailChanged(
     scoped_refptr<MediaSource> source) {
-  std::cout << " OnMediaSourceThumbnailChanged: " << source->id().std_string()
-            << std::endl;
-
   EncodableMap info;
   info[EncodableValue("event")] = "desktopSourceThumbnailChanged";
   info[EncodableValue("id")] = EncodableValue(source->id().std_string());
@@ -135,19 +131,12 @@ void FlutterScreenCapture::OnMediaSourceThumbnailChanged(
 }
 
 void FlutterScreenCapture::OnStart(scoped_refptr<RTCDesktopCapturer> capturer) {
-  // std::cout << " OnStart: " << capturer->source()->id().std_string()
-  //          << std::endl;
 }
 
 void FlutterScreenCapture::OnPaused(
-    scoped_refptr<RTCDesktopCapturer> capturer) {
-  // std::cout << " OnPaused: " << capturer->source()->id().std_string()
-  //          << std::endl;
-}
+    scoped_refptr<RTCDesktopCapturer> capturer) {}
 
 void FlutterScreenCapture::OnStop(scoped_refptr<RTCDesktopCapturer> capturer) {
-  // std::cout << " OnStop: " << capturer->source()->id().std_string()
-  //          << std::endl;
   if (loopback_capturer_) {
     loopback_capturer_->Stop();
     loopback_capturer_.reset();
@@ -156,8 +145,6 @@ void FlutterScreenCapture::OnStop(scoped_refptr<RTCDesktopCapturer> capturer) {
 }
 
 void FlutterScreenCapture::OnError(scoped_refptr<RTCDesktopCapturer> capturer) {
-  // std::cout << " OnError: " << capturer->source()->id().std_string()
-  //          << std::endl;
 }
 
 void FlutterScreenCapture::GetDesktopSourceThumbnail(
@@ -177,8 +164,6 @@ void FlutterScreenCapture::GetDesktopSourceThumbnail(
     result->Error("Bad Arguments", "Failed to get desktop source thumbnail");
     return;
   }
-  std::cout << " GetDesktopSourceThumbnail: " << source->id().std_string()
-            << std::endl;
   source->UpdateThumbnail();
   result->Success(EncodableValue(source->thumbnail().std_vector()));
 }
@@ -302,6 +287,29 @@ void FlutterScreenCapture::GetDisplayMedia(
       source = src;
     }
   }
+
+#ifdef __linux__
+  // If the caller didn't specify a source (source_id == "0"), fall back to
+  // the first available screen. When a specific source_id was requested but
+  // isn't in the (possibly stale) cached list, rebuild the list and retry
+  // the match instead of silently capturing the wrong source.
+  if (!source.get() && !sources_.empty() && source_id == "0") {
+    source = sources_.front();
+  }
+  if (!source.get()) {
+    EncodableList types;
+    types.push_back(EncodableValue(std::string("screen")));
+    BuildDesktopSourcesList(types, true);
+    for (auto src : sources_) {
+      if (src->id().std_string() == source_id) {
+        source = src;
+      }
+    }
+    if (!source.get() && !sources_.empty() && source_id == "0") {
+      source = sources_.front();
+    }
+  }
+#endif
 
   if (!source.get()) {
     result->Error("Bad Arguments", "source not found!");

--- a/linux/flutter/core_implementations.cc
+++ b/linux/flutter/core_implementations.cc
@@ -45,6 +45,9 @@ static gboolean fl_texture_proxy_copy_pixels(FlPixelBufferTexture* texture,
                                              uint32_t* height,
                                              GError** error) {
   FlTextureProxy* proxy = FL_TEXTURE_PROXY(texture);
+  if (proxy->texture == nullptr) {
+    return TRUE;
+  }
   flutter::PixelBufferTexture& pixel_buffer =
       std::get<flutter::PixelBufferTexture>(*proxy->texture);
   const FlutterDesktopPixelBuffer* copy =
@@ -246,6 +249,7 @@ bool TextureRegistrarImpl::UnregisterTexture(int64_t texture_id) {
   if (it != textures_.end()) {
     auto texture = it->second;
     textures_.erase(it);
+    FL_TEXTURE_PROXY(texture)->texture = nullptr;
     bool success = fl_texture_registrar_unregister_texture(
         texture_registrar_ref_, FL_TEXTURE(texture));
     g_object_unref(texture);


### PR DESCRIPTION
fix(linux): guard texture proxy and harden desktop source enumeration (#2129)

**Problem**

Linux desktop screen capture has two crash/fragility issues.

**(A) Use-after-free in the GTK texture proxy** (`linux/flutter/core_implementations.cc`)

`fl_texture_proxy_copy_pixels` does an unguarded
`std::get<flutter::PixelBufferTexture>(*proxy->texture)`. If the texture
variant is destroyed before the proxy `GObject` is torn down (a race during
unregister), this dereferences freed memory and crashes. `UnregisterTexture`
also calls `fl_texture_registrar_unregister_texture` *before* nulling
`proxy->texture`, leaving a window in which the engine's copy-pixels callback
can fire against a destroyed variant.

**(B) Fragile desktop source enumeration** (`common/cpp/src/flutter_screen_capture.cc`)

`BuildDesktopSourcesList` calls `UpdateSourceList` with no exception guard; on
Linux this can throw during transient desktop-enumerator failures, aborting
the whole enumeration. `GetDisplayMedia` also errors with `"source not found!"`
when the requested `source_id` is absent from a stale cached list, even though
a re-enumeration would have found it.

A number of leftover `std::cout` debug statements were also present.

**Fix**

- `fl_texture_proxy_copy_pixels`: null-check `proxy->texture` before `std::get`
  (return `TRUE` to avoid crashing the engine copy path).
- `UnregisterTexture`: null `FL_TEXTURE_PROXY(texture)->texture` *before*
  `fl_texture_registrar_unregister_texture`, closing the race.
- `BuildDesktopSourcesList`: on `__linux__`, wrap `UpdateSourceList` in
  `try/catch` so a transient failure skips that source type instead of aborting.
- `GetDisplayMedia`: on `__linux__`, when the requested `source_id` is not in the
  cached list, rebuild the list and retry the match. The first-available
  (`sources_.front()`) fallback is only used when the caller did not specify a
  source (`source_id == "0"`); a specifically-requested source that still isn't
  found falls through to the existing `"source not found!"` error rather than
  silently capturing the wrong surface.
- Remove the leftover debug `std::cout` statements.

### Testing

- `git clang-format` reports no violations on the changed lines (Chromium style).
- Validated in the originating Linux desktop application (Kohera, using
  `livekit_client`): rapid start/stop of screen-share capture no longer crashes
  during the texture unregister race, and transient desktop-enumerator failures
  no longer abort source enumeration.

Fixes #2129

Co-authored-by: Claude <noreply@anthropic.com>