### PR TITLE
fix(macos): use legacy capturer on Monterey

### DIFF
--- a/common/darwin/Classes/FlutterRTCDesktopCapturer.m
+++ b/common/darwin/Classes/FlutterRTCDesktopCapturer.m
@@ -148,7 +148,9 @@ NSArray<RTCDesktopSource*>* _captureSources;
     }
   }
   if (useScreenCaptureKit) {
-    if (@available(macOS 12.3, *)) {
+    // ScreenCaptureKit can create a live track without delivering frames on
+    // macOS Monterey. Use the legacy WebRTC capturer on macOS 12.x.
+    if (@available(macOS 13.0, *)) {
       screenCaptureKitCapturer =
           [[FlutterScreenCaptureKitCapturer alloc] initWithDelegate:videoProcessingAdapter];
       [screenCaptureKitCapturer startCaptureWithFPS:fps
@@ -162,7 +164,7 @@ NSArray<RTCDesktopSource*>* _captureSources;
                                             }
                                           }];
     } else {
-      NSLog(@"ScreenCaptureKit not available, falling back to RTCDesktopCapturer");
+      NSLog(@"ScreenCaptureKit unavailable or unsupported, falling back to RTCDesktopCapturer");
       desktopCapturer = [[RTCDesktopCapturer alloc] initWithDefaultScreen:self
                                                           captureDelegate:videoProcessingAdapter];
     }


### PR DESCRIPTION
## Summary

Use the legacy `RTCDesktopCapturer` on macOS Monterey and enable the ScreenCaptureKit-based capturer only on macOS 13.0 and later.

## Problem

On macOS Monterey, ScreenCaptureKit may successfully create a live video track without delivering any video frames. This results in an apparently active screen-sharing session that displays no video.

## Solution

Change the ScreenCaptureKit availability check from macOS 12.3 to macOS 13.0.

On macOS 12.x, screen capture now falls back to `RTCDesktopCapturer`. ScreenCaptureKit remains enabled on macOS 13.0 and later.

## Expected behavior

- macOS 12.x: use `RTCDesktopCapturer`
- macOS 13.0+: use `FlutterScreenCaptureKitCapturer`
- Window capture behavior remains unchanged

## Context

This is a follow-up to #1991, which originally introduced ScreenCaptureKit support with a legacy capturer fallback.