### PR TITLE
fix(darwin): deliver FrameCryptor state events reliably and fail safe on decrypt failure

### DIFF
--- a/common/darwin/Classes/FlutterRTCFrameCryptor.h
+++ b/common/darwin/Classes/FlutterRTCFrameCryptor.h
@@ -11,6 +11,10 @@
 @interface RTCFrameCryptor (Flutter) <FlutterStreamHandler>
 @property(nonatomic, strong, nullable) FlutterEventSink eventSink;
 @property(nonatomic, strong, nullable) FlutterEventChannel* eventChannel;
+// Buffers state-change events fired by the native cryptor before the Dart side
+// has attached its event-channel listener, so they are not lost. Mirrors the
+// Android implementation's eventQueue. Flushed in -onListenWithArguments:.
+@property(nonatomic, strong, nullable) NSMutableArray* eventQueue;
 @end
 
 

--- a/common/darwin/Classes/FlutterRTCFrameCryptor.m
+++ b/common/darwin/Classes/FlutterRTCFrameCryptor.m
@@ -22,6 +22,15 @@
                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
+- (NSMutableArray*)eventQueue {
+  return objc_getAssociatedObject(self, _cmd);
+}
+
+- (void)setEventQueue:(NSMutableArray*)eventQueue {
+  objc_setAssociatedObject(self, @selector(eventQueue), eventQueue,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 #pragma mark - FlutterStreamHandler methods
 
 - (FlutterError* _Nullable)onCancelWithArguments:(id _Nullable)arguments {
@@ -32,6 +41,16 @@
 - (FlutterError* _Nullable)onListenWithArguments:(id _Nullable)arguments
                                        eventSink:(nonnull FlutterEventSink)sink {
   self.eventSink = sink;
+  // Flush any state-change events that fired before the Dart listener attached
+  // (e.g. an immediate decryptionFailed), matching the Android eventQueue.
+  NSArray* queued;
+  @synchronized(self) {
+    queued = [self.eventQueue copy];
+    [self.eventQueue removeAllObjects];
+  }
+  for (id event in queued) {
+    postEvent(sink, event);
+  }
   return nil;
 }
 @end
@@ -169,6 +188,7 @@
                                                         frameCryptorId]
              binaryMessenger:self.messenger];
 
+    frameCryptor.eventQueue = [NSMutableArray array];
     frameCryptor.eventChannel = eventChannel;
     [eventChannel setStreamHandler:frameCryptor];
     frameCryptor.delegate = self;
@@ -195,6 +215,7 @@
                                                         frameCryptorId]
              binaryMessenger:self.messenger];
 
+    frameCryptor.eventQueue = [NSMutableArray array];
     frameCryptor.eventChannel = eventChannel;
     [eventChannel setStreamHandler:frameCryptor];
     frameCryptor.delegate = self;
@@ -318,6 +339,17 @@
   }
   [self.frameCryptors removeObjectForKey:frameCryptorId];
   frameCryptor.enabled = NO;
+  // Tear down so the native cryptor stops delivering state events to a disposed
+  // object and the eventChannel<->frameCryptor retain cycle is broken (the
+  // channel retains its stream handler, the handler retains the channel via the
+  // associated object). Mirrors Android's frameCryptor.dispose().
+  frameCryptor.delegate = nil;
+  [frameCryptor.eventChannel setStreamHandler:nil];
+  frameCryptor.eventChannel = nil;
+  frameCryptor.eventSink = nil;
+  @synchronized(frameCryptor) {
+    [frameCryptor.eventQueue removeAllObjects];
+  }
   result(@{@"result" : @"success"});
 }
 
@@ -607,12 +639,22 @@
 - (void)frameCryptor:(RTC_OBJC_TYPE(RTCFrameCryptor) *)frameCryptor
     didStateChangeWithParticipantId:(NSString*)participantId
                           withState:(RTCFrameCryptorState)stateChanged {
+  // participantId may be an empty/absent value coming from the native layer;
+  // never insert nil into the dictionary literal (that raises
+  // NSInvalidArgumentException and crashes the process).
+  NSDictionary* event = @{
+    @"event" : @"frameCryptionStateChanged",
+    @"participantId" : participantId ?: @"",
+    @"state" : [self stringFromState:stateChanged]
+  };
   if (frameCryptor.eventSink) {
-    postEvent(frameCryptor.eventSink, @{
-      @"event" : @"frameCryptionStateChanged",
-      @"participantId" : participantId,
-      @"state" : [self stringFromState:stateChanged]
-    });
+    postEvent(frameCryptor.eventSink, event);
+  } else {
+    // No Dart listener yet: buffer so a state such as decryptionFailed that
+    // fires right after creation is delivered once -onListen attaches.
+    @synchronized(frameCryptor) {
+      [frameCryptor.eventQueue addObject:event];
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

FrameCryptor (frame-level E2EE) works on Android but users report it crashing / hanging on iOS & macOS (#1789, #1325). This PR makes the **Darwin** FrameCryptor state-delivery path match the (non-crashing) **Android** implementation and fail safe on a decryption failure.

> **Honesty note for reviewers:** this is a **code-level parity/hardening fix derived by comparing the Darwin and Android bridges**, not one confirmed against a live symbolicated crash trace. I was unable to stand up a two-peer E2EE session on real Apple hardware to force a decrypt failure and capture a trace. The reporters in #1789/#1325 did not attach traces either. The reasoning is below so it can be scrutinised; please build/verify against the example before merging.

## Root cause

The task's usual suspect — emitting the event **off the platform thread** — is **already fixed on `main`**: `postEvent()` wraps delivery in `dispatch_async(dispatch_get_main_queue(), …)` and nil-guards the sink (`FlutterWebRTCPlugin.m`, landed in #1458). So that is not the remaining bug.

Comparing `common/darwin/Classes/FlutterRTCFrameCryptor.m` against `android/.../FlutterRTCFrameCryptor.java`, three divergences remain on Darwin:

1. **State events are dropped instead of queued.** Android buffers events in an `eventQueue` when no listener is attached yet and flushes them in `onListen` (`AnyThreadSink` + `eventQueue`). On Darwin the delegate simply does nothing when `eventSink == nil`. The Dart side attaches its `EventChannel.receiveBroadcastStream().listen(...)` **after** the native factory call returns (`lib/src/native/frame_cryptor_impl.dart`, `FrameCryptorImpl` constructor), so any state that fires in that window — notably an immediate `decryptionFailed` / `missingKey` on a wrong/rotated key — is lost. This matches the "E2EE doesn't work / screen stuck" symptom.

2. **`nil` `participantId` crashes the process.** In `-frameCryptor:didStateChangeWithParticipantId:withState:` the value was inserted directly into an `NSDictionary` literal. A nil value raises `NSInvalidArgumentException` ("attempt to insert nil object"), on the delegate thread.

3. **No teardown on dispose.** `frameCryptorDispose` only removed the entry and set `enabled = NO`. It never cleared the delegate or the stream handler, so the native cryptor keeps delivering state events to a disposed object, and `eventChannel` (retained as an associated object of the cryptor) and the cryptor (retained as the channel's stream handler) form a retain cycle. Android calls `frameCryptor.dispose()`.

## Fix

Mirror Android in `common/darwin/Classes/FlutterRTCFrameCryptor.{h,m}`:

- Add an `eventQueue` on the `RTCFrameCryptor (Flutter)` category; buffer state events when no sink is attached and **flush them in `-onListenWithArguments:`**.
- **Guard `participantId`** (`participantId ?: @""`) before building the event dictionary.
- On dispose, **tear down**: `delegate = nil`, `setStreamHandler:nil`, drop the channel/sink, clear the queue — stopping stray events and breaking the retain cycle.
- Guard the cross-thread `eventQueue` with `@synchronized` (it is mutated on the WebRTC worker thread and read on the main thread).

The **failure state still reaches Dart** — only the crash and the lost-event window are removed. No AES-GCM/crypto math is touched and there is **no change to the prebuilt libwebrtc binary**.

## Diff

`common/darwin/Classes/FlutterRTCFrameCryptor.h` (+4), `common/darwin/Classes/FlutterRTCFrameCryptor.m` (+47/−5). No formatting churn.

## Testing / verification status

- ✅ Static comparison against the Android implementation for each transition (`new`, `ok`, `encryptionFailed`, `decryptionFailed`, `missingKey`, `keyRatcheted`, `internalError`).
- ✅ All `RTCFrameCryptorState` cases handled in `stringFromState:`.
- ⚠️ **Not** verified against a live macOS/iOS E2EE call or a symbolicated trace (see honesty note). Suggested manual test for a reviewer with Apple hardware:
  1. Run `example/` E2EE sample on macOS + an iOS device, two peers.
  2. Matching keys → confirm audio/video decrypts (parity with Android).
  3. Set a mismatched/rotated key on one side → confirm the app **no longer crashes** and a `FrameCryptorState.decryptionFailed` (or `missingKey`) reaches the Dart `onFrameCryptorStateChanged` callback.
  4. Re-run the same path on Android → **no regression**.

## Related

Relates to #1789, #1325. Context: #300, #1249. Darwin FrameCryptor was added in #1201.
