### PR TITLE
fix(ios): restore simulator microphone capture

### DIFF
--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -368,7 +368,7 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
         // iOS devices also require the AudioEngine ADM because the CoreAudio ADM
         // crashes when NSMicrophoneUsageDescription is absent (#2007, #2009).
         RTCAudioDeviceModuleType audioDeviceModuleType = RTCAudioDeviceModuleTypeAudioEngine;
-#if TARGET_OS_IPHONE && TARGET_OS_SIMULATOR
+#if TARGET_OS_IOS && TARGET_OS_SIMULATOR
         // The AudioEngine ADM can expose a zero-rate input on the iOS Simulator.
         audioDeviceModuleType = RTCAudioDeviceModuleTypePlatformDefault;
 #endif

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -355,7 +355,7 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
         VideoEncoderFactorySimulcast* simulcastFactory =
             [[VideoEncoderFactorySimulcast alloc] initWithPrimary:encoderFactory fallback:encoderFactory];
 
-        // Use the AVAudioEngine audio device module on both iOS and macOS.
+        // Use the AVAudioEngine audio device module on iOS devices and macOS.
         //
         // macOS previously used the CoreAudio ADM (value 0) to avoid an
         // AVAudioIONodeImpl::SetOutputFormat sample-rate assertion when the
@@ -365,9 +365,13 @@ static __weak id<RTCAudioDeviceModuleDelegate> gAudioDeviceModuleObserver = nil;
         // state-based voice-processing checks, engine recreate ordering).
         // The AudioEngine ADM enables platform voice processing (Apple
         // AEC/NS/AGC) and the audio processing options API on macOS.
-        // iOS also requires the AudioEngine ADM because the CoreAudio ADM
+        // iOS devices also require the AudioEngine ADM because the CoreAudio ADM
         // crashes when NSMicrophoneUsageDescription is absent (#2007, #2009).
         RTCAudioDeviceModuleType audioDeviceModuleType = RTCAudioDeviceModuleTypeAudioEngine;
+#if TARGET_OS_IPHONE && TARGET_OS_SIMULATOR
+        // The AudioEngine ADM can expose a zero-rate input on the iOS Simulator.
+        audioDeviceModuleType = RTCAudioDeviceModuleTypePlatformDefault;
+#endif
         _peerConnectionFactory =
             [[RTCPeerConnectionFactory alloc] initWithAudioDeviceModuleType:audioDeviceModuleType
                                                       bypassVoiceProcessing:bypassVoiceProcessing


### PR DESCRIPTION
## Summary

- Use the platform-default audio device module on the iOS Simulator.
- Keep the AVAudioEngine audio device module on physical iOS devices and macOS.

## Why

On current iOS Simulator runtimes, the AVAudioEngine audio device module can expose a zero-rate microphone input. `getUserMedia` still returns an audio track, but it produces no samples or RTP packets. The platform-default module restores capture.

The change is limited at compile time to the iOS Simulator, so production-device behavior is unchanged.

## Validation

Tested with Flutter 3.44.0, Xcode 26.5, and an iPhone 17 Pro simulator running iOS 26.3.1:

- Before: `packetsSent=0`, `bytesSent=0`, `totalSamplesDuration=0.0`.
- After: 100 packets and 5,250 bytes after 2 seconds; sample duration and audio energy continued increasing.
- A clean receive-only app without `NSMicrophoneUsageDescription` still starts without a permission prompt or crash.
- `dart format`, import sorter, `flutter analyze`, and `flutter test` pass.
- iOS release builds pass with both Swift Package Manager and CocoaPods.

Fixes #2139
