### PR TITLE
fix(desktop): sanitize screen/window names before sending them to Flutter

### DIFF
--- a/common/cpp/src/flutter_screen_capture.cc
+++ b/common/cpp/src/flutter_screen_capture.cc
@@ -1,4 +1,5 @@
 #include "flutter_screen_capture.h"
+#include "flutter_utf8_sanitize.h"
 
 #include <stdexcept>
 
@@ -59,7 +60,8 @@ void FlutterScreenCapture::GetDesktopSources(
   for (auto source : sources_) {
     EncodableMap info;
     info[EncodableValue("id")] = EncodableValue(source->id().std_string());
-    info[EncodableValue("name")] = EncodableValue(source->name().std_string());
+    info[EncodableValue("name")] =
+        EncodableValue(SanitizeUtf8ForFlutter(source->name().std_string()));
     info[EncodableValue("type")] =
         EncodableValue(source->type() == kWindow ? "window" : "screen");
     // TODO "thumbnailSize"
@@ -92,7 +94,8 @@ void FlutterScreenCapture::OnMediaSourceAdded(
   EncodableMap info;
   info[EncodableValue("event")] = "desktopSourceAdded";
   info[EncodableValue("id")] = EncodableValue(source->id().std_string());
-  info[EncodableValue("name")] = EncodableValue(source->name().std_string());
+  info[EncodableValue("name")] =
+      EncodableValue(SanitizeUtf8ForFlutter(source->name().std_string()));
   info[EncodableValue("type")] =
       EncodableValue(source->type() == kWindow ? "window" : "screen");
   // TODO "thumbnailSize"
@@ -116,7 +119,8 @@ void FlutterScreenCapture::OnMediaSourceNameChanged(
   EncodableMap info;
   info[EncodableValue("event")] = "desktopSourceNameChanged";
   info[EncodableValue("id")] = EncodableValue(source->id().std_string());
-  info[EncodableValue("name")] = EncodableValue(source->name().std_string());
+  info[EncodableValue("name")] =
+      EncodableValue(SanitizeUtf8ForFlutter(source->name().std_string()));
   base_->event_channel()->Success(EncodableValue(info));
 }
 


### PR DESCRIPTION
### Problem

`GetDesktopSources`, `OnMediaSourceAdded` and `OnMediaSourceRemoved` put the raw source name straight into an `EncodableValue`:

```cpp
info[EncodableValue("name")] = EncodableValue(source->name().std_string());
```

Window titles are arbitrary user text and are **not guaranteed to be valid UTF-8 on Windows**. The standard method codec UTF-8-decodes every string it writes, so a single window whose title the codec cannot decode fails the **entire** `getDesktopSources` reply — the picker comes back empty and screen sharing looks broken, with no visible cause.

It is easy to miss: a machine whose windows all happen to have ASCII titles never reproduces it. I hit it consistently with Turkish window titles.

### Fix

Route the three call sites through `SanitizeUtf8ForFlutter`, the helper this repo already has for exactly this. Ids and types are untouched.

### Notes

- Three call sites, one include, no behaviour change for names that are already valid UTF-8.
- Lines wrapped to keep the file within its existing 80-column style.