### PR TITLE
feat(desktop): support the getDisplayMedia "cursor" constraint

### DIFF
--- a/common/cpp/src/flutter_screen_capture.cc
+++ b/common/cpp/src/flutter_screen_capture.cc
@@ -174,6 +174,10 @@ void FlutterScreenCapture::GetDisplayMedia(
   std::string source_id = "0";
   // DesktopType source_type = kScreen;
   double fps = 30.0;
+  // Whether the OS cursor is composited into the captured frames, driven by the
+  // getDisplayMedia "cursor" video constraint. Defaults to true so behaviour is
+  // unchanged when the constraint is absent — that is libwebrtc's own default.
+  bool show_cursor = true;
 
   const EncodableMap video = findMap(constraints, "video");
   if (video != EncodableMap()) {
@@ -194,6 +198,15 @@ void FlutterScreenCapture::GetDisplayMedia(
       if (frameRate != 0.0) {
         fps = frameRate;
       }
+    }
+    // Accept both the spec's string form ("always"/"never") and a plain bool.
+    // Only an explicitly supplied constraint moves off the default, so callers
+    // that pass no "cursor" key keep exactly the behaviour they have today.
+    const std::string cursor = findString(video, "cursor");
+    if (!cursor.empty()) {
+      show_cursor = (cursor == "always");
+    } else if (video.find(EncodableValue("cursor")) != video.end()) {
+      show_cursor = findBoolean(video, "cursor");
     }
   }
 
@@ -317,7 +330,7 @@ void FlutterScreenCapture::GetDisplayMedia(
   }
 
   scoped_refptr<RTCDesktopCapturer> desktop_capturer =
-      base_->desktop_device_->CreateDesktopCapturer(source);
+      base_->desktop_device_->CreateDesktopCapturer(source, show_cursor);
 
   if (!desktop_capturer.get()) {
     result->Error("Bad Arguments", "CreateDesktopCapturer failed!");

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -8,6 +8,23 @@ import '../flutter_webrtc.dart';
 import 'native_logs_listener.dart';
 
 class Helper {
+  /// Whether the sharer's OS mouse cursor is composited into desktop screen
+  /// capture (native getDisplayMedia on Windows/Linux).
+  ///
+  /// Read when a capture starts, so it applies to the NEXT screen share rather
+  /// than one already running. Defaults to `true` — the existing behaviour —
+  /// so nothing changes unless an app opts out. Set it to `false` to avoid the
+  /// "double cursor" viewers see when the sharer's pointer is drawn on top of
+  /// their own. Web is unaffected: the browser owns cursor handling there.
+  static bool screenCaptureShowCursor = true;
+
+  /// Show/hide the broadcaster's mouse cursor in desktop screen capture.
+  /// Applies to the NEXT screen share started via getDisplayMedia; an already
+  /// running capture is unaffected.
+  static void setScreenCaptureCursor(bool show) {
+    screenCaptureShowCursor = show;
+  }
+
   /// Set Logger object for webrtc;
   ///
   /// Params:

--- a/lib/src/native/mediadevices_impl.dart
+++ b/lib/src/native/mediadevices_impl.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 
 import 'package:webrtc_interface/webrtc_interface.dart';
 
+import '../helper.dart';
 import 'event_channel.dart';
 import 'media_stream_impl.dart';
 import 'utils.dart';
@@ -52,6 +53,31 @@ class MediaDeviceNative extends MediaDevices {
   @override
   Future<MediaStream> getDisplayMedia(
       Map<String, dynamic> mediaConstraints) async {
+    // Forward Helper.screenCaptureShowCursor to the native capturer as the
+    // getDisplayMedia "cursor" video constraint. Only added when the caller has
+    // not set one itself, so an explicit constraint always wins. Copy-on-write
+    // so the caller's constraints map is never mutated.
+    if (WebRTC.platformIsDesktop) {
+      final cursor = Helper.screenCaptureShowCursor ? 'always' : 'never';
+      final video = mediaConstraints['video'];
+      if (video is Map) {
+        mediaConstraints = <String, dynamic>{
+          ...mediaConstraints,
+          'video': <String, dynamic>{
+            ...Map<String, dynamic>.from(video),
+            if (!video.containsKey('cursor')) 'cursor': cursor,
+          },
+        };
+      } else if (video == true) {
+        // `video: true` carries no source/fps info; the native handler treats
+        // an empty video map identically (same defaults), so it is safe to
+        // upgrade it to a map that only carries the cursor preference.
+        mediaConstraints = <String, dynamic>{
+          ...mediaConstraints,
+          'video': <String, dynamic>{'cursor': cursor},
+        };
+      }
+    }
     try {
       final response = await WebRTC.invokeMethod(
         'getDisplayMedia',


### PR DESCRIPTION
Closes #1630. Also requested in #1696 and #1963.

### Problem

Desktop screen capture always composites the sharer's mouse pointer into the frames, so viewers see **two cursors** — the sharer's, painted into the video, floating on top of their own. In a call it is distracting, and to everyone watching it looks like a bug.

libwebrtc already supports turning this off:

```cpp
virtual scoped_refptr<RTCDesktopCapturer> CreateDesktopCapturer(
    scoped_refptr<MediaSource> source, bool showCursor = true) = 0;
```

The plugin simply never passed anything to it.

### Change

- Parse the standard getDisplayMedia `cursor` video constraint and forward it to `CreateDesktopCapturer`. Both spec forms are accepted: the string (`"always"` / `"never"`) and a plain bool.
- `Helper.screenCaptureShowCursor` lets an app set the preference once instead of threading a constraint through every call site. An explicit constraint in `mediaConstraints` always wins over the helper.

### Compatibility

**No behaviour change by default.** `show_cursor` starts `true` and only an explicitly supplied constraint moves it, which matches libwebrtc's own default — callers that pass no `cursor` key behave exactly as before.

Web is untouched: the browser owns cursor handling there.