### PR TITLE
perf(windows): run AddTransceiver/AddTrack off the platform thread

### DIFF
--- a/common/cpp/src/flutter_peerconnection.cc
+++ b/common/cpp/src/flutter_peerconnection.cc
@@ -6,6 +6,12 @@
 #include "rtc_dtmf_sender.h"
 #include "rtc_rtp_parameters.h"
 
+#ifdef _WIN32
+// Worker thread for off-platform-thread track publish
+// (see AddTransceiver / AddTrack).
+#include <thread>
+#endif
+
 namespace flutter_webrtc_plugin {
 
 std::string RTCMediaTypeToString(RTCMediaType type) {
@@ -633,31 +639,59 @@ void FlutterPeerConnection::AddTransceiver(
     std::unique_ptr<MethodResultProxy> result) {
   std::shared_ptr<MethodResultProxy> result_ptr(result.release());
 
-  RTCMediaTrack* track = base_->MediaTrackForId(trackId);
+  // Hold a ref to the track (base_ owns one in local_tracks_) so it stays alive
+  // for the possibly-deferred worker below. May be null (the mediaType path).
+  scoped_refptr<RTCMediaTrack> track = base_->MediaTrackForId(trackId);
   RTCMediaType type = stringToMediaType(mediaType);
 
-  if (0 < transceiverInit.size()) {
-    auto transceiver =
-        track != nullptr ? pc->AddTransceiver(
-                               track, mapToRtpTransceiverInit(transceiverInit))
-                         : pc->AddTransceiver(
-                               type, mapToRtpTransceiverInit(transceiverInit));
-    if (nullptr != transceiver.get()) {
-      result_ptr->Success(EncodableValue(transceiverToMap(transceiver)));
-      return;
+  // Parse the init on the CALLING thread (cheap, no signaling-thread work) and
+  // capture the refcounted result — so the worker below needs neither the
+  // EncodableMap nor the FlutterPeerConnection instance.
+  const bool has_init = 0 < transceiverInit.size();
+  scoped_refptr<RTCRtpTransceiverInit> init =
+      has_init ? mapToRtpTransceiverInit(transceiverInit)
+               : scoped_refptr<RTCRtpTransceiverInit>();
+
+  // The actual libwebrtc call + result completion. pc->AddTransceiver() is a
+  // proxy that BLOCKS the caller until the signaling thread finishes it.
+  auto do_add = [pc, track, type, has_init, init, result_ptr]() {
+    if (has_init) {
+      auto transceiver = track.get() != nullptr
+                             ? pc->AddTransceiver(track.get(), init)
+                             : pc->AddTransceiver(type, init);
+      if (nullptr != transceiver.get()) {
+        result_ptr->Success(EncodableValue(transceiverToMap(transceiver)));
+        return;
+      }
+      result_ptr->Error("AddTransceiver(track | mediaType, init)",
+                        "AddTransceiver error");
+    } else {
+      auto transceiver = track.get() != nullptr ? pc->AddTransceiver(track.get())
+                                                : pc->AddTransceiver(type);
+      if (nullptr != transceiver.get()) {
+        result_ptr->Success(EncodableValue(transceiverToMap(transceiver)));
+        return;
+      }
+      result_ptr->Error("AddTransceiver(track, mediaType)",
+                        "AddTransceiver error");
     }
-    result_ptr->Error("AddTransceiver(track | mediaType, init)",
-                      "AddTransceiver error");
-  } else {
-    auto transceiver =
-        track != nullptr ? pc->AddTransceiver(track) : pc->AddTransceiver(type);
-    if (nullptr != transceiver.get()) {
-      result_ptr->Success(EncodableValue(transceiverToMap(transceiver)));
-      return;
-    }
-    result_ptr->Error("AddTransceiver(track, mediaType)",
-                      "AddTransceiver error");
-  }
+  };
+
+#ifdef _WIN32
+  // the FIRST audio transceiver triggers the cold publish
+  // init (RTP audio sender + Opus encoder + APM allocation), ~600ms, and
+  // pc->AddTransceiver() blocks the caller for the whole time. LiveKit publishes
+  // the mic via addTransceiver (engine.dart), so on Flutter Windows — where the
+  // platform thread IS the UI message loop — first voice join froze the mouse
+  // for ~600ms. Run it on a worker and complete the MethodResult from there
+  // (house style, see CreateOffer). The proxy is thread-safe (it marshals to the
+  // signaling thread regardless of caller), and LiveKit awaits this result
+  // before it negotiates (createOffer/setLocalDescription), so ordering holds.
+  // pc outlives the in-flight publish (Dart awaits this before any teardown).
+  std::thread(std::move(do_add)).detach();
+#else
+  do_add();
+#endif
 }
 
 void FlutterPeerConnection::GetTransceivers(
@@ -1137,23 +1171,39 @@ void FlutterPeerConnection::AddTrack(
     std::vector<std::string> streamIds,
     std::unique_ptr<MethodResultProxy> result) {
   std::shared_ptr<MethodResultProxy> result_ptr(result.release());
-  std::string kind = track->kind().std_string();
-  if (0 == kind.compare("audio")) {
-    auto sender =
-        pc->AddTrack(reinterpret_cast<RTCAudioTrack*>(track.get()), streamIds);
-    if (sender.get() != nullptr) {
-      result_ptr->Success(EncodableValue(rtpSenderToMap(sender)));
-      return;
+
+  // The actual libwebrtc call + result completion. pc->AddTrack() is a proxy
+  // that BLOCKS the caller until the signaling thread finishes it (which, for a
+  // first audio track, includes the cold RTP-sender/encoder/APM init).
+  auto do_add = [pc, track, streamIds, result_ptr]() {
+    std::string kind = track->kind().std_string();
+    if (0 == kind.compare("audio")) {
+      auto sender =
+          pc->AddTrack(reinterpret_cast<RTCAudioTrack*>(track.get()), streamIds);
+      if (sender.get() != nullptr) {
+        result_ptr->Success(EncodableValue(rtpSenderToMap(sender)));
+        return;
+      }
+    } else if (0 == kind.compare("video")) {
+      auto sender =
+          pc->AddTrack(reinterpret_cast<RTCVideoTrack*>(track.get()), streamIds);
+      if (sender.get() != nullptr) {
+        result_ptr->Success(EncodableValue(rtpSenderToMap(sender)));
+        return;
+      }
     }
-  } else if (0 == kind.compare("video")) {
-    auto sender =
-        pc->AddTrack(reinterpret_cast<RTCVideoTrack*>(track.get()), streamIds);
-    if (sender.get() != nullptr) {
-      result_ptr->Success(EncodableValue(rtpSenderToMap(sender)));
-      return;
-    }
-  }
-  result->Success();
+    result_ptr->Success();  // was result->Success() — a use-after-release bug
+  };
+
+#ifdef _WIN32
+  // same rationale as AddTransceiver — run the blocking
+  // proxy call off the platform (UI) thread so a track publish can't freeze the
+  // mouse. LiveKit uses addTransceiver for publishing, but keep AddTrack off the
+  // UI thread too for any code path that goes through it.
+  std::thread(std::move(do_add)).detach();
+#else
+  do_add();
+#endif
 }
 
 void FlutterPeerConnection::RemoveTrack(


### PR DESCRIPTION
### Problem

`pc->AddTransceiver()` and `AddTrack()` are proxy calls — they **block the caller** until the signaling thread has finished. On Windows the Flutter platform thread is the UI message loop, so publishing a track blocks the whole interface: the app stops painting and the cursor stops responding.

In my app, joining a voice call was a visible freeze of roughly **600 ms**, most of it the *first* audio transceiver — that is the call that brings the transport up.

### Change

Move the blocking part to a detached worker, following the pattern this file already uses for `CreateOffer`/`CreateAnswer` rather than introducing a new one.

The constraints map is parsed on the calling thread first, so the worker captures only refcounted objects (`pc`, the track, the parsed init, the result proxy) — it needs neither the `EncodableMap` nor the `FlutterPeerConnection` instance, and so cannot outlive anything it touches.

### Safety

- The proxy is thread-safe: it marshals to the signaling thread regardless of which thread calls it.
- The result is completed from the worker, so **ordering as seen by Dart is unchanged** — the caller still awaits exactly one completion.
- Guarded by `#ifdef _WIN32`, since that is where the platform thread is the message loop and where the freeze is visible. Other platforms keep the current path.

Happy to widen it beyond Windows, or to fold it behind the same helper as the offer/answer path, if you would prefer either.