### PR TITLE
fix(windows): don't unregister event channel handlers after engine teardown

### DIFF
--- a/common/cpp/include/flutter_common.h
+++ b/common/cpp/include/flutter_common.h
@@ -186,4 +186,12 @@ class EventChannelProxy {
                        bool cache_event = true) = 0;
 };
 
+// Records the host (embedder) messenger handle captured at plugin
+// registration. It is used to check that the engine is still running before
+// an event channel unregisters its stream handler during teardown, see
+// ~EventChannelProxyImpl. The handle is opaque here so this shared header
+// stays platform-neutral; platforms without the FlutterDesktopMessenger C API
+// never call this and keep the unguarded behaviour.
+void SetEventChannelHostMessenger(void* messenger_ref);
+
 #endif  // FLUTTER_WEBRTC_COMMON_HXX

--- a/common/cpp/src/flutter_common.cc
+++ b/common/cpp/src/flutter_common.cc
@@ -3,6 +3,19 @@
 
 #include <memory>
 
+#if defined(_WIN32)
+#include <flutter_messenger.h>
+#endif
+
+// See SetEventChannelHostMessenger() in flutter_common.h. Only ever written
+// from plugin registration, which happens on the platform thread before any
+// event channel exists.
+static void* g_host_messenger = nullptr;
+
+void SetEventChannelHostMessenger(void* messenger_ref) {
+  g_host_messenger = messenger_ref;
+}
+
 class MethodCallProxyImpl : public MethodCallProxy {
  public:
   explicit MethodCallProxyImpl(const MethodCall& method_call)
@@ -122,6 +135,14 @@ class EventChannelProxyImpl : public EventChannelProxy {
              channelName,
              &flutter::StandardMethodCodec::GetInstance())),
              task_runner_(task_runner) {
+#if defined(_WIN32)
+     // Each proxy keeps its own reference so that the handle outlives the
+     // engine it belongs to and the Release() below stays balanced.
+     if (g_host_messenger) {
+       host_messenger_ = FlutterDesktopMessengerAddRef(
+           static_cast<FlutterDesktopMessengerRef>(g_host_messenger));
+     }
+#endif
      auto handler = std::make_unique<
          flutter::StreamHandlerFunctions<EncodableValue>>(
          [&](const EncodableValue* arguments,
@@ -145,7 +166,29 @@ class EventChannelProxyImpl : public EventChannelProxy {
      channel_->SetStreamHandler(std::move(handler));
    }
 
-   virtual ~EventChannelProxyImpl() { channel_->SetStreamHandler(nullptr); }
+   virtual ~EventChannelProxyImpl() {
+     // Unregister the stream handler only while the messenger still
+     // references a running engine. This destructor also runs from
+     // PluginRegistrar::ClearPlugins() during FlutterWindowsEngine teardown,
+     // after the engine has detached itself from the FlutterDesktopMessenger;
+     // an unconditional SetStreamHandler(nullptr) then reaches
+     // FlutterDesktopMessengerSetCallback, which dereferences the detached
+     // engine (its FML_DCHECK is compiled out in release builds): access
+     // violation on the platform thread. The registration dies with the
+     // engine anyway.
+#if defined(_WIN32)
+     if (host_messenger_) {
+       FlutterDesktopMessengerLock(host_messenger_);
+       if (FlutterDesktopMessengerIsAvailable(host_messenger_)) {
+         channel_->SetStreamHandler(nullptr);
+       }
+       FlutterDesktopMessengerUnlock(host_messenger_);
+       FlutterDesktopMessengerRelease(host_messenger_);
+       return;
+     }
+#endif
+     channel_->SetStreamHandler(nullptr);
+   }
 
    void Success(const EncodableValue& event, bool cache_event = true) override {
      if (on_listen_called_) {
@@ -177,6 +220,9 @@ class EventChannelProxyImpl : public EventChannelProxy {
    std::list<EncodableValue> event_queue_;
    bool on_listen_called_ = false;
    TaskRunner* task_runner_;
+#if defined(_WIN32)
+   FlutterDesktopMessengerRef host_messenger_ = nullptr;
+#endif
  };
 
 std::unique_ptr<EventChannelProxy> EventChannelProxy::Create(

--- a/windows/flutter_webrtc_plugin.cc
+++ b/windows/flutter_webrtc_plugin.cc
@@ -5,6 +5,8 @@
 #include "task_runner_windows.h"
 
 #include <flutter/plugin_registrar_windows.h>
+#include <flutter_messenger.h>
+#include <flutter_plugin_registrar.h>
 
 const char* kChannelName = "FlutterWebRTC.Method";
 static flutter_webrtc_plugin::FlutterWebRTC* g_shared_instance = nullptr;
@@ -74,6 +76,13 @@ class FlutterWebRTCPluginImpl : public FlutterWebRTCPlugin {
 
 void FlutterWebRTCPluginRegisterWithRegistrar(
     FlutterDesktopPluginRegistrarRef registrar) {
+  // Capture the host messenger before creating the plugin, so that the event
+  // channels can check whether the engine is still running before they
+  // unregister their stream handlers; see ~EventChannelProxyImpl in
+  // common/cpp/src/flutter_common.cc. The AddRef() here keeps the handle
+  // itself valid after the engine is gone.
+  SetEventChannelHostMessenger(FlutterDesktopMessengerAddRef(
+      FlutterDesktopPluginRegistrarGetMessenger(registrar)));
   flutter_webrtc_plugin::FlutterWebRTCPluginImpl::RegisterWithRegistrar(
       flutter::PluginRegistrarManager::GetInstance()
           ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));

--- a/windows/flutter_webrtc_plugin.cc
+++ b/windows/flutter_webrtc_plugin.cc
@@ -79,10 +79,9 @@ void FlutterWebRTCPluginRegisterWithRegistrar(
   // Capture the host messenger before creating the plugin, so that the event
   // channels can check whether the engine is still running before they
   // unregister their stream handlers; see ~EventChannelProxyImpl in
-  // common/cpp/src/flutter_common.cc. The AddRef() here keeps the handle
-  // itself valid after the engine is gone.
-  SetEventChannelHostMessenger(FlutterDesktopMessengerAddRef(
-      FlutterDesktopPluginRegistrarGetMessenger(registrar)));
+  // common/cpp/src/flutter_common.cc.
+  SetEventChannelHostMessenger(
+      FlutterDesktopPluginRegistrarGetMessenger(registrar));
   flutter_webrtc_plugin::FlutterWebRTCPluginImpl::RegisterWithRegistrar(
       flutter::PluginRegistrarManager::GetInstance()
           ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));


### PR DESCRIPTION

`~EventChannelProxyImpl` unconditionally called
`channel_->SetStreamHandler(nullptr)`. On Windows that destructor also runs from `PluginRegistrar::ClearPlugins()` during `FlutterWindowsEngine` teardown, which happens *after* the engine has detached itself from the `FlutterDesktopMessenger`. The call then reaches
`FlutterDesktopMessengerSetCallback`, which dereferences the detached engine — its `FML_DCHECK` that the messenger must reference a running engine is compiled out in release builds — and the process dies with an access violation (0xc000041d) on the platform thread on every exit.

Merely depending on the plugin is enough to hit this: the base event channel proxy is created eagerly when `FlutterWebRTCBase` is constructed at registration, so it is always alive at engine teardown.

Capture the host messenger at plugin registration and have each event channel proxy hold its own reference to it (`AddRef`/`Release`, so the handle outlives the engine and the refcount stays balanced across the base channel and the per-peer-connection / data-channel / video-renderer channels). The destructor now unregisters only while `FlutterDesktopMessengerIsAvailable` reports a live engine under the messenger lock; during teardown the registration dies with the engine anyway. Non-Windows builds of the shared `common/cpp` code keep the previous unguarded behaviour.

Regression from #2131. Fixes #2151.